### PR TITLE
Add MapQuery attribute support for QUERY HTTP verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ public sealed class GetTodo
 
 Key points:
 
-* Use `[MapGet]`, `[MapPost]`, `[MapPut]`, `[MapDelete]`, `[MapPatch]`, `[MapHead]`, `[MapOptions]`, `[MapTrace]`, or `[MapConnect]` to describe the HTTP verb and route pattern.
+* Use `[MapGet]`, `[MapPost]`, `[MapPut]`, `[MapDelete]`, `[MapPatch]`, `[MapHead]`, `[MapOptions]`, `[MapQuery]`, `[MapTrace]`, or `[MapConnect]` to describe the HTTP verb and route pattern.
 * Optional `Name`, `Summary`, and `Description` named parameters populate the generated `.WithName`, `.WithSummary`, and `.WithDescription` metadata calls. When omitted, the generator derives the endpoint name from the method name (stripping a trailing `Async`).
 * Apply standard ASP.NET Core parameter binding attributes (`[FromRoute]`, `[FromQuery]`, `[FromBody]`, `[FromServices]`, `[AsParameters]`, etc.). The generator mirrors them onto the produced delegate so binding behaves exactly as declared.
 * Annotate the **class**, an individual **method**, or both with `[Tags]`, `[RequireAuthorization]`, or `[DisableAntiforgery]`. Class-level metadata is merged onto every generated endpoint, while method-level attributes can refine or augment the settings for a specific handler.

--- a/src/GeneratedEndpoints/MinimalApiGenerator.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.cs
@@ -43,6 +43,10 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
     private const string MapPatchAttributeFullyQualifiedName = $"{AttributesNamespace}.{MapPatchAttributeName}";
     private const string MapPatchAttributeHint = $"{MapPatchAttributeFullyQualifiedName}.gs.cs";
 
+    private const string MapQueryAttributeName = "MapQueryAttribute";
+    private const string MapQueryAttributeFullyQualifiedName = $"{AttributesNamespace}.{MapQueryAttributeName}";
+    private const string MapQueryAttributeHint = $"{MapQueryAttributeFullyQualifiedName}.gs.cs";
+
     private const string MapTraceAttributeName = "MapTraceAttribute";
     private const string MapTraceAttributeFullyQualifiedName = $"{AttributesNamespace}.{MapTraceAttributeName}";
     private const string MapTraceAttributeHint = $"{MapTraceAttributeFullyQualifiedName}.gs.cs";
@@ -128,6 +132,11 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             .WhereNotNull()
             .Collect();
 
+        var queryRequestHandlers = context.SyntaxProvider
+            .ForAttributeWithMetadataName(MapQueryAttributeFullyQualifiedName, RequestHandlerFilter, RequestHandlerTransform)
+            .WhereNotNull()
+            .Collect();
+
         var traceRequestHandlers = context.SyntaxProvider
             .ForAttributeWithMetadataName(MapTraceAttributeFullyQualifiedName, RequestHandlerFilter, RequestHandlerTransform)
             .WhereNotNull()
@@ -150,6 +159,8 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             .Select(static (x, _) => x.Left.AddRange(x.Right))
             .Combine(headRequestHandlers)
             .Select(static (x, _) => x.Left.AddRange(x.Right))
+            .Combine(queryRequestHandlers)
+            .Select(static (x, _) => x.Left.AddRange(x.Right))
             .Combine(traceRequestHandlers)
             .Select(static (x, _) => x.Left.AddRange(x.Right))
             .Combine(connectRequestHandlers)
@@ -170,6 +181,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             (Name: MapOptionsAttributeName, FullyQualified: MapOptionsAttributeFullyQualifiedName, Hint: MapOptionsAttributeHint, Verb: "OPTIONS"),
             (Name: MapHeadAttributeName, FullyQualified: MapHeadAttributeFullyQualifiedName, Hint: MapHeadAttributeHint, Verb: "HEAD"),
             (Name: MapPatchAttributeName, FullyQualified: MapPatchAttributeFullyQualifiedName, Hint: MapPatchAttributeHint, Verb: "PATCH"),
+            (Name: MapQueryAttributeName, FullyQualified: MapQueryAttributeFullyQualifiedName, Hint: MapQueryAttributeHint, Verb: "QUERY"),
             (Name: MapTraceAttributeName, FullyQualified: MapTraceAttributeFullyQualifiedName, Hint: MapTraceAttributeHint, Verb: "TRACE"),
             (Name: MapConnectAttributeName, FullyQualified: MapConnectAttributeFullyQualifiedName, Hint: MapConnectAttributeHint, Verb: "CONNECT"),
         };
@@ -345,6 +357,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             MapOptionsAttributeName => "OPTIONS",
             MapHeadAttributeName => "HEAD",
             MapPatchAttributeName => "Patch",
+            MapQueryAttributeName => "QUERY",
             MapTraceAttributeName => "TRACE",
             MapConnectAttributeName => "CONNECT",
             _ => "",
@@ -875,7 +888,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         source.Append('(');
         source.Append(StringLiteral(requestHandler.Pattern));
         source.Append(", ");
-        if (requestHandler.HttpMethod is "OPTIONS" or "HEAD" or "TRACE" or "CONNECT")
+        if (requestHandler.HttpMethod is "OPTIONS" or "HEAD" or "TRACE" or "CONNECT" or "QUERY")
         {
             source.Append("new[] { \"");
             source.Append(requestHandler.HttpMethod);


### PR DESCRIPTION
## Summary
- add a `MapQuery` attribute, pipeline wiring, and generator handling so QUERY endpoints map via `MapMethods`
- document the new attribute in the README

## Testing
- dotnet test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d5229f448328865cc5177eea788e)