### PR TITLE
Add AllowAnonymous attribute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Key points:
 * Use `[MapGet]`, `[MapPost]`, `[MapPut]`, `[MapDelete]`, `[MapPatch]`, `[MapHead]`, `[MapOptions]`, `[MapQuery]`, `[MapTrace]`, or `[MapConnect]` to describe the HTTP verb and route pattern.
 * Optional `Name`, `Summary`, and `Description` named parameters populate the generated `.WithName`, `.WithSummary`, and `.WithDescription` metadata calls. When omitted, the generator derives the endpoint name from the method name (stripping a trailing `Async`).
 * Apply standard ASP.NET Core parameter binding attributes (`[FromRoute]`, `[FromQuery]`, `[FromBody]`, `[FromServices]`, `[AsParameters]`, etc.). The generator mirrors them onto the produced delegate so binding behaves exactly as declared.
-* Annotate the **class**, an individual **method**, or both with `[Tags]`, `[RequireAuthorization]`, or `[DisableAntiforgery]`. Class-level metadata is merged onto every generated endpoint, while method-level attributes can refine or augment the settings for a specific handler.
+* Annotate the **class**, an individual **method**, or both with `[Tags]`, `[RequireAuthorization]`, `[DisableAntiforgery]`, or `[AllowAnonymous]`. Class-level metadata is merged onto every generated endpoint, while method-level attributes can refine or augment the settings for a specific handler. `[AllowAnonymous]` lets a method opt out of authorization even if the enclosing class (or other conventions) require authenticated access.
 * Non-static handler classes are automatically registered with dependency injection (as transient services). Their instance methods receive a scoped instance resolved from DI, while static methods continue to behave like any other static helper.
 
 #### Static handler example

--- a/src/GeneratedEndpoints/MinimalApiGenerator.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.cs
@@ -67,6 +67,10 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
     private const string DisableAntiforgeryAttributeFullyQualifiedName = $"{AttributesNamespace}.{DisableAntiforgeryAttributeName}";
     private const string DisableAntiforgeryAttributeHint = $"{DisableAntiforgeryAttributeFullyQualifiedName}.gs.cs";
 
+    private const string AllowAnonymousAttributeName = "AllowAnonymousAttribute";
+    private const string AllowAnonymousAttributeFullyQualifiedName = $"{AttributesNamespace}.{AllowAnonymousAttributeName}";
+    private const string AllowAnonymousAttributeHint = $"{AllowAnonymousAttributeFullyQualifiedName}.gs.cs";
+
     private const string RoutingNamespace = $"{BaseNamespace}.Routing";
 
     private const string AddEndpointHandlersClassName = "EndpointServicesExtensions";
@@ -245,6 +249,23 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
 
                                          """;
         context.AddSource(DisableAntiforgeryAttributeHint, SourceText.From(disableAntiforgerySource, Encoding.UTF8));
+
+        // AllowAnonymous
+        var allowAnonymousSource = $$"""
+                                     {{FileHeader}}
+
+                                     namespace {{AttributesNamespace}};
+
+                                     /// <summary>
+                                     /// Allows the annotated endpoint or class to bypass authorization requirements.
+                                     /// </summary>
+                                     [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+                                     internal sealed class {{AllowAnonymousAttributeName}} : global::System.Attribute
+                                     {
+                                     }
+
+                                     """;
+        context.AddSource(AllowAnonymousAttributeHint, SourceText.From(allowAnonymousSource, Encoding.UTF8));
     }
 
     private static string GenerateHttpAttributeSource(string fileHeader, string attributesNamespace, string attributeName, string summaryVerb)
@@ -317,7 +338,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
 
         var (httpMethod, pattern, name, summary, description) = GetRequestHandlerAttribute(attribute, cancellationToken);
 
-        var (tags, requireAuthorization, authorizationPolicies, disableAntiforgery) =
+        var (tags, requireAuthorization, authorizationPolicies, disableAntiforgery, allowAnonymous) =
             GetAdditionalRequestHandlerAttributes(requestHandlerClassSymbol, requestHandlerMethodSymbol, cancellationToken);
 
         name ??= RemoveAsyncSuffix(requestHandlerMethod.Name);
@@ -325,7 +346,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         var metadata = new RequestHandlerMetadata(name, summary, description, tags);
 
         var requestHandler = new RequestHandler(requestHandlerClass, requestHandlerMethod, httpMethod, pattern, metadata, requireAuthorization,
-            authorizationPolicies, disableAntiforgery
+            authorizationPolicies, disableAntiforgery, allowAnonymous
         );
 
         return requestHandler;
@@ -397,7 +418,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
     }
 
     private static (EquatableImmutableArray<string>? tags, bool requireAuthorization, EquatableImmutableArray<string>? authorizationPolicies, bool
-        disableAntiforgery) GetAdditionalRequestHandlerAttributes(INamedTypeSymbol classSymbol, IMethodSymbol methodSymbol, CancellationToken cancellationToken)
+        disableAntiforgery, bool allowAnonymous) GetAdditionalRequestHandlerAttributes(INamedTypeSymbol classSymbol, IMethodSymbol methodSymbol, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -405,14 +426,15 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         var requireAuthorization = false;
         EquatableImmutableArray<string>? authorizationPolicies = null;
         var disableAntiforgery = false;
+        var allowAnonymous = false;
 
         var classAttributes = classSymbol.GetAttributes();
-        GetAdditionalRequestHandlerAttributeValues(classAttributes, ref tags, ref requireAuthorization, ref authorizationPolicies, ref disableAntiforgery);
+        GetAdditionalRequestHandlerAttributeValues(classAttributes, ref tags, ref requireAuthorization, ref authorizationPolicies, ref disableAntiforgery, ref allowAnonymous);
 
         var methodAttributes = methodSymbol.GetAttributes();
-        GetAdditionalRequestHandlerAttributeValues(methodAttributes, ref tags, ref requireAuthorization, ref authorizationPolicies, ref disableAntiforgery);
+        GetAdditionalRequestHandlerAttributeValues(methodAttributes, ref tags, ref requireAuthorization, ref authorizationPolicies, ref disableAntiforgery, ref allowAnonymous);
 
-        return (tags, requireAuthorization, authorizationPolicies, disableAntiforgery);
+        return (tags, requireAuthorization, authorizationPolicies, disableAntiforgery, allowAnonymous);
     }
 
     private static void GetAdditionalRequestHandlerAttributeValues(
@@ -420,7 +442,8 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         ref EquatableImmutableArray<string>? tags,
         ref bool requireAuthorization,
         ref EquatableImmutableArray<string>? authorizationPolicies,
-        ref bool disableAntiforgery
+        ref bool disableAntiforgery,
+        ref bool allowAnonymous
     )
     {
         foreach (var attribute in attributes)
@@ -466,6 +489,9 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                     break;
                 case $"global::{DisableAntiforgeryAttributeFullyQualifiedName}":
                     disableAntiforgery = true;
+                    break;
+                case $"global::{AllowAnonymousAttributeFullyQualifiedName}":
+                    allowAnonymous = true;
                     break;
             }
         }
@@ -993,6 +1019,13 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             source.Append(".DisableAntiforgery()");
         }
 
+        if (requestHandler.AllowAnonymous)
+        {
+            source.AppendLine();
+            source.Append(continuationIndent);
+            source.Append(".AllowAnonymous()");
+        }
+
         if (wrapWithConfigure && configureAcceptsServiceProvider)
         {
             source.AppendLine(",");
@@ -1060,6 +1093,8 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             if (rh.AuthorizationPolicies is { Count: > 0 })
                 cost += rh.AuthorizationPolicies.Value.Sum(p => 6 + p.Length);
             if (rh.DisableAntiforgery)
+                cost += 24;
+            if (rh.AllowAnonymous)
                 cost += 24;
             if (rh.Class.HasConfigureMethod)
             {
@@ -1208,7 +1243,8 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         RequestHandlerMetadata Metadata,
         bool RequireAuthorization,
         EquatableImmutableArray<string>? AuthorizationPolicies,
-        bool DisableAntiforgery
+        bool DisableAntiforgery,
+        bool AllowAnonymous
     );
 
     private readonly record struct RequestHandlerClass(


### PR DESCRIPTION
## Summary
- generate a new `[AllowAnonymous]` attribute alongside the existing antiforgery metadata
- capture an `AllowAnonymous` flag for each handler and emit `.AllowAnonymous()` in the generated endpoint mappings when present
- document the new attribute so consumers know how to opt a handler out of authorization requirements

## Testing
- `dotnet test`
- `dotnet test --no-build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d6655ff88328b6294707924aab25)