### PR TITLE
Use built-in AllowAnonymous attribute

### DIFF
--- a/src/GeneratedEndpoints/MinimalApiGenerator.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.cs
@@ -67,9 +67,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
     private const string DisableAntiforgeryAttributeFullyQualifiedName = $"{AttributesNamespace}.{DisableAntiforgeryAttributeName}";
     private const string DisableAntiforgeryAttributeHint = $"{DisableAntiforgeryAttributeFullyQualifiedName}.gs.cs";
 
-    private const string AllowAnonymousAttributeName = "AllowAnonymousAttribute";
-    private const string AllowAnonymousAttributeFullyQualifiedName = $"{AttributesNamespace}.{AllowAnonymousAttributeName}";
-    private const string AllowAnonymousAttributeHint = $"{AllowAnonymousAttributeFullyQualifiedName}.gs.cs";
+    private const string AllowAnonymousAttributeFullyQualifiedName = "Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute";
 
     private const string AcceptsAttributeName = "AcceptsAttribute";
     private const string AcceptsAttributeFullyQualifiedName = $"{AttributesNamespace}.{AcceptsAttributeName}";
@@ -266,23 +264,6 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
 
                                          """;
         context.AddSource(DisableAntiforgeryAttributeHint, SourceText.From(disableAntiforgerySource, Encoding.UTF8));
-
-        // AllowAnonymous
-        var allowAnonymousSource = $$"""
-                                     {{FileHeader}}
-
-                                     namespace {{AttributesNamespace}};
-
-                                     /// <summary>
-                                     /// Allows the annotated endpoint or class to bypass authorization requirements.
-                                     /// </summary>
-                                     [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-                                     internal sealed class {{AllowAnonymousAttributeName}} : global::System.Attribute
-                                     {
-                                     }
-
-                                     """;
-        context.AddSource(AllowAnonymousAttributeHint, SourceText.From(allowAnonymousSource, Encoding.UTF8));
 
         // Accepts
         var acceptsSource = $$"""

--- a/tests/GeneratedEndpoints.Tests.Lab/GetUserEndpoint.cs
+++ b/tests/GeneratedEndpoints.Tests.Lab/GetUserEndpoint.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Generated.Attributes;
 using Microsoft.AspNetCore.Http;

--- a/tests/GeneratedEndpoints.Tests/Common/TestHelpers.cs
+++ b/tests/GeneratedEndpoints.Tests/Common/TestHelpers.cs
@@ -18,6 +18,7 @@ public static class TestHelpers
     public static IEnumerable<string> GetSources(string source, bool withNamespace)
     {
         const string usingStatements = """
+                                       using Microsoft.AspNetCore.Authorization;
                                        using Microsoft.AspNetCore.Generated.Attributes;
                                        using Microsoft.AspNetCore.Http;
                                        using Microsoft.AspNetCore.Http.HttpResults;


### PR DESCRIPTION
## Summary
- update the generator to reference the framework-provided `AllowAnonymousAttribute` instead of emitting a custom copy
- ensure the test scaffolding and lab sample import `Microsoft.AspNetCore.Authorization` so `[AllowAnonymous]` resolves to the built-in attribute

## Testing
- dotnet test --nologo

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e4a9be88832891cf206f793f5478)