### PR TITLE
Propagate ExcludeFromDescription metadata

### DIFF
--- a/src/GeneratedEndpoints/MinimalApiGenerator.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.cs
@@ -594,8 +594,8 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
 
         var (httpMethod, pattern, name, summary, description) = GetRequestHandlerAttribute(attribute, cancellationToken);
 
-        var (tags, requireAuthorization, authorizationPolicies, disableAntiforgery, allowAnonymous, accepts, produces,
-                producesProblem, producesValidationProblem)
+        var (tags, requireAuthorization, authorizationPolicies, disableAntiforgery, allowAnonymous, excludeFromDescription,
+                accepts, produces, producesProblem, producesValidationProblem)
             = GetAdditionalRequestHandlerAttributes(requestHandlerClassSymbol, requestHandlerMethodSymbol, cancellationToken);
 
         name ??= RemoveAsyncSuffix(requestHandlerMethod.Name);
@@ -608,7 +608,8 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             accepts,
             produces,
             producesProblem,
-            producesValidationProblem
+            producesValidationProblem,
+            excludeFromDescription
         );
 
         var requestHandler = new RequestHandler(requestHandlerClass, requestHandlerMethod, httpMethod, pattern, metadata, requireAuthorization,
@@ -689,6 +690,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         EquatableImmutableArray<string>? authorizationPolicies,
         bool disableAntiforgery,
         bool allowAnonymous,
+        bool excludeFromDescription,
         EquatableImmutableArray<AcceptsMetadata>? accepts,
         EquatableImmutableArray<ProducesMetadata>? produces,
         EquatableImmutableArray<ProducesProblemMetadata>? producesProblem,
@@ -702,6 +704,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         EquatableImmutableArray<string>? authorizationPolicies = null;
         var disableAntiforgery = false;
         var allowAnonymous = false;
+        var excludeFromDescription = false;
 
         List<AcceptsMetadata>? accepts = null;
         List<ProducesMetadata>? produces = null;
@@ -716,6 +719,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             ref authorizationPolicies,
             ref disableAntiforgery,
             ref allowAnonymous,
+            ref excludeFromDescription,
             ref accepts,
             ref produces,
             ref producesProblem,
@@ -730,6 +734,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             ref authorizationPolicies,
             ref disableAntiforgery,
             ref allowAnonymous,
+            ref excludeFromDescription,
             ref accepts,
             ref produces,
             ref producesProblem,
@@ -742,6 +747,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             authorizationPolicies,
             disableAntiforgery,
             allowAnonymous,
+            excludeFromDescription,
             ToEquatableOrNull(accepts),
             ToEquatableOrNull(produces),
             ToEquatableOrNull(producesProblem),
@@ -756,6 +762,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         ref EquatableImmutableArray<string>? authorizationPolicies,
         ref bool disableAntiforgery,
         ref bool allowAnonymous,
+        ref bool excludeFromDescription,
         ref List<AcceptsMetadata>? accepts,
         ref List<ProducesMetadata>? produces,
         ref List<ProducesProblemMetadata>? producesProblem,
@@ -820,6 +827,9 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                     break;
                 case $"global::{AllowAnonymousAttributeFullyQualifiedName}":
                     allowAnonymous = true;
+                    break;
+                case "global::Microsoft.AspNetCore.Routing.ExcludeFromDescriptionAttribute":
+                    excludeFromDescription = true;
                     break;
                 case $"global::{ProducesProblemAttributeFullyQualifiedName}":
                 {
@@ -1467,6 +1477,13 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             source.Append(')');
         }
 
+        if (requestHandler.Metadata.ExcludeFromDescription)
+        {
+            source.AppendLine();
+            source.Append(continuationIndent);
+            source.Append(".ExcludeFromDescription()");
+        }
+
         if (requestHandler.Metadata.Tags is { Count: > 0 })
         {
             source.AppendLine();
@@ -1623,6 +1640,8 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                 cost += 24 + metadata.Summary.Length;
             if (metadata.Description is { Length: > 0 })
                 cost += 28 + metadata.Description.Length;
+            if (metadata.ExcludeFromDescription)
+                cost += 32;
 
             if (metadata.Tags is { Count: > 0 })
                 cost += metadata.Tags.Value.Sum(tag => 6 + tag.Length);
@@ -1872,7 +1891,8 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         EquatableImmutableArray<AcceptsMetadata>? Accepts,
         EquatableImmutableArray<ProducesMetadata>? Produces,
         EquatableImmutableArray<ProducesProblemMetadata>? ProducesProblem,
-        EquatableImmutableArray<ProducesValidationProblemMetadata>? ProducesValidationProblem
+        EquatableImmutableArray<ProducesValidationProblemMetadata>? ProducesValidationProblem,
+        bool ExcludeFromDescription
     );
 
     private readonly record struct AcceptsMetadata(string RequestType, string ContentType, EquatableImmutableArray<string>? AdditionalContentTypes);

--- a/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.MapAllAttributesAndHttpMethods_MapEndpointHandlers_WithNamespace.verified.txt
+++ b/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.MapAllAttributesAndHttpMethods_MapEndpointHandlers_WithNamespace.verified.txt
@@ -53,6 +53,7 @@ internal static class EndpointRouteBuilderExtensions
             .WithName("GetComplex")
             .WithSummary("Gets complex data.")
             .WithDescription("Uses every supported attribute.")
+            .ExcludeFromDescription()
             .WithTags("Shared", "ClassLevel", "MethodLevel")
             .Accepts<global::GeneratedEndpointsTests.ClassLevelRequest>("application/xml", "text/xml")
             .Accepts<global::GeneratedEndpointsTests.GetRequest>("application/custom", "text/custom")

--- a/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.MapAllAttributesAndHttpMethods_MapEndpointHandlers_WithoutNamespace.verified.txt
+++ b/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.MapAllAttributesAndHttpMethods_MapEndpointHandlers_WithoutNamespace.verified.txt
@@ -53,6 +53,7 @@ internal static class EndpointRouteBuilderExtensions
             .WithName("GetComplex")
             .WithSummary("Gets complex data.")
             .WithDescription("Uses every supported attribute.")
+            .ExcludeFromDescription()
             .WithTags("Shared", "ClassLevel", "MethodLevel")
             .Accepts<global::ClassLevelRequest>("application/xml", "text/xml")
             .Accepts<global::GetRequest>("application/custom", "text/custom")

--- a/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.cs
+++ b/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.cs
@@ -119,6 +119,7 @@ public class GeneratedEndpointsTests
                                                [Microsoft.AspNetCore.Generated.Attributes.ProducesResponse(typeof(ClassLevelResponse), 201, "application/json", "text/json")]
                                              [ProducesProblem(503, "application/problem+json")]
                                              [ProducesValidationProblem(409, "application/problem+json", "text/plain")]
+                                             [Microsoft.AspNetCore.Routing.ExcludeFromDescription]
                                              internal sealed class ComplexEndpoints
                                              {
                                                  private readonly IServiceProvider _serviceProvider;
@@ -141,6 +142,7 @@ public class GeneratedEndpointsTests
                                                    [Microsoft.AspNetCore.Generated.Attributes.ProducesResponse<GetResponse>(200, "application/json", "text/json")]
                                                  [ProducesProblem(400, "application/problem+json", "text/plain")]
                                                  [ProducesValidationProblem(422, "application/problem+json", "text/plain")]
+                                                 [Microsoft.AspNetCore.Routing.ExcludeFromDescription]
                                                  public async Task<Results<Ok<GetResponse>, NotFound>> GetComplex(
                                                      [FromRoute] int id,
                                                      [FromQuery] string? filter,


### PR DESCRIPTION
## Summary
- propagate the ExcludeFromDescription attribute through request handler metadata and emit .ExcludeFromDescription() in generated endpoint mappings
- update the complex test fixture and verified snapshots to cover the attribute on both the class and method

## Testing
- dotnet test --no-build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e6e39b38832893ae6ff1a72b9a5c)