### PR TITLE
Allow null response type for non-generic attribute

### DIFF
--- a/src/GeneratedEndpoints/MinimalApiGenerator.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.cs
@@ -358,7 +358,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                                 /// <summary>
                                 /// Gets the response type produced by the endpoint.
                                 /// </summary>
-                                public global::System.Type ResponseType { get; init; } = default!;
+                                public global::System.Type? ResponseType { get; init; } = null;
 
                                     /// <summary>
                                     /// Gets the HTTP status code returned by the endpoint.


### PR DESCRIPTION
## Summary
- allow the ResponseType property on the non-generic ProducesResponseAttribute to be nullable so it no longer requires a default type

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ed97ccb08328ba6a27e96ca0305f)