### PR TITLE
Add DisplayName metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ GeneratedEndpoints is a .NET source generator that automatically wires Minimal A
 
 GeneratedEndpoints focuses on three goals:
 
-* **Attribute-driven routing** – use `[MapGet]`, `[MapPost]`, `[MapDelete]`, `[MapOptions]`, `[MapHead]`, `[MapPatch]`, `[MapTrace]`, `[MapConnect]`, and even `[MapQuery]` to describe the verb and route pattern. The generator creates the matching `Map*` call and wires up metadata like `.WithName`, `.WithSummary`, and `.WithDescription`.
+* **Attribute-driven routing** – use `[MapGet]`, `[MapPost]`, `[MapDelete]`, `[MapOptions]`, `[MapHead]`, `[MapPatch]`, `[MapTrace]`, `[MapConnect]`, and even `[MapQuery]` to describe the verb and route pattern. The generator creates the matching `Map*` call and wires up metadata like `.WithName`, `.WithDisplayName`, `.WithSummary`, and `.WithDescription`.
 * **Feature-first organization** – keep handlers close to the code they execute (for example, alongside your `Todos` feature). Non-static handler classes are automatically registered with dependency injection so you can inject EF Core DbContexts, services, etc.
 * **Metadata composition** – decorate classes and methods with `[Tags]`, `[RequireAuthorization]`, `[DisableAntiforgery]`, `[AllowAnonymous]`, and `[ExcludeFromDescription]`. Apply `[Accepts]`, `[ProducesResponse]`, `[ProducesProblem]`, and `[ProducesValidationProblem]` directly to the methods they describe. Class-level metadata is merged into every method, while method-level metadata can refine or override.
 
@@ -76,7 +76,7 @@ public sealed class GetTodo
 Key ideas:
 
 * Choose the attribute that matches the verb (`[MapGet]`, `[MapPost]`, `[MapPut]`, `[MapDelete]`, `[MapPatch]`, `[MapHead]`, `[MapOptions]`, `[MapTrace]`, `[MapConnect]`, `[MapQuery]`).
-* Named arguments like `Summary`, `Description`, and `Name` are translated into `.WithSummary`, `.WithDescription`, and `.WithName` calls.
+* Named arguments like `DisplayName`, `Summary`, `Description`, and `Name` are translated into `.WithDisplayName`, `.WithSummary`, `.WithDescription`, and `.WithName` calls.
 * Use existing ASP.NET Core binding attributes (`[FromRoute]`, `[FromQuery]`, `[FromBody]`, `[FromHeader]`, `[FromServices]`, `[FromKeyedServices]`, `[AsParameters]`, etc.). The generator preserves them in the produced delegate.
 * Metadata attributes (`[Tags]`, `[RequireAuthorization]`, `[AllowAnonymous]`, `[DisableAntiforgery]`, `[ExcludeFromDescription]`) can be placed on the class, on a method, or on both. Class-level metadata is merged with method-level metadata. Request/response attributes (`[Accepts]`, `[ProducesResponse]`, `[ProducesProblem]`, `[ProducesValidationProblem]`) must be applied directly to the method they describe.
 
@@ -248,7 +248,7 @@ public sealed class CreateTodo
 
 | Attribute | Scope | Purpose |
 | --- | --- | --- |
-| `[MapGet]`, `[MapPost]`, `[MapPut]`, `[MapDelete]`, `[MapPatch]`, `[MapHead]`, `[MapOptions]`, `[MapTrace]`, `[MapConnect]`, `[MapQuery]` | Method | Declares an endpoint and its route pattern. Named arguments fill the generated `.WithName`, `.WithSummary`, and `.WithDescription` calls. |
+| `[MapGet]`, `[MapPost]`, `[MapPut]`, `[MapDelete]`, `[MapPatch]`, `[MapHead]`, `[MapOptions]`, `[MapTrace]`, `[MapConnect]`, `[MapQuery]` | Method | Declares an endpoint and its route pattern. Named arguments fill the generated `.WithName`, `.WithDisplayName`, `.WithSummary`, and `.WithDescription` calls. |
 | `[Tags]` | Class or method | Adds tags to one or more endpoints. Multiple attributes merge without duplication. |
 | `[RequireAuthorization]` | Class or method | Requires authorization for the endpoint. Passing policies (`[RequireAuthorization("Todos.Read", "Todos.Write")]`) emits `.RequireAuthorization("Todos.Read", "Todos.Write")`. |
 | `[AllowAnonymous]` | Class or method | Explicitly opts an endpoint into anonymous access, overriding `[RequireAuthorization]`. |

--- a/src/GeneratedEndpoints/MinimalApiGenerator.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.cs
@@ -41,6 +41,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         HttpAttributeDefinitions.ToImmutableDictionary(static definition => definition.Name);
 
     private const string NameAttributeNamedParameter = "Name";
+    private const string DisplayNameAttributeNamedParameter = "DisplayName";
     private const string SummaryAttributeNamedParameter = "Summary";
     private const string DescriptionAttributeNamedParameter = "Description";
     private const string ResponseTypeAttributeNamedParameter = "ResponseType";
@@ -740,6 +741,11 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                      public string Name { get; set; } = "";
 
                      /// <summary>
+                     /// Gets or sets the endpoint display name.
+                     /// </summary>
+                     public string DisplayName { get; set; } = "";
+
+                     /// <summary>
                      /// Gets or sets the endpoint summary.
                      /// </summary>
                      public string Summary { get; set; } = "";
@@ -784,7 +790,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
 
         var requestHandlerMethod = GetRequestHandlerMethod(requestHandlerMethodSymbol, cancellationToken);
 
-        var (httpMethod, pattern, name, summary, description) = GetRequestHandlerAttribute(attribute, cancellationToken);
+        var (httpMethod, pattern, name, displayName, summary, description) = GetRequestHandlerAttribute(attribute, cancellationToken);
 
         var (tags, requireAuthorization, authorizationPolicies, disableAntiforgery, allowAnonymous, excludeFromDescription,
                 accepts, produces, producesProblem, producesValidationProblem, requireCors, corsPolicyName, requireRateLimiting,
@@ -796,6 +802,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
 
         var metadata = new RequestHandlerMetadata(
             name,
+            displayName,
             summary,
             description,
             tags,
@@ -823,7 +830,14 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         return methodName;
     }
 
-    private static (string HttpMethod, string Pattern, string? Name, string? Summary, string? Description) GetRequestHandlerAttribute(
+    private static (
+        string HttpMethod,
+        string Pattern,
+        string? Name,
+        string? DisplayName,
+        string? Summary,
+        string? Description
+    ) GetRequestHandlerAttribute(
         AttributeData attribute,
         CancellationToken cancellationToken
     )
@@ -839,6 +853,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         var pattern = (attribute.ConstructorArguments.Length > 0 ? attribute.ConstructorArguments[0].Value as string : "") ?? "";
 
         string? name = null;
+        string? displayName = null;
         string? summary = null;
         string? description = null;
         foreach (var namedArg in attribute.NamedArguments)
@@ -849,6 +864,12 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                 {
                     var value = namedArg.Value.Value as string;
                     name = string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
+                    break;
+                }
+                case DisplayNameAttributeNamedParameter:
+                {
+                    var value = namedArg.Value.Value as string;
+                    displayName = string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
                     break;
                 }
                 case SummaryAttributeNamedParameter:
@@ -866,7 +887,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             }
         }
 
-        return (httpMethod, pattern, name, summary, description);
+        return (httpMethod, pattern, name, displayName, summary, description);
     }
 
     private static (
@@ -2005,6 +2026,15 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             source.Append(')');
         }
 
+        if (!string.IsNullOrEmpty(requestHandler.Metadata.DisplayName))
+        {
+            source.AppendLine();
+            source.Append(continuationIndent);
+            source.Append(".WithDisplayName(");
+            source.Append(StringLiteral(requestHandler.Metadata.DisplayName));
+            source.Append(')');
+        }
+
         if (!string.IsNullOrEmpty(requestHandler.Metadata.Summary))
         {
             source.AppendLine();
@@ -2455,6 +2485,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
 
     private readonly record struct RequestHandlerMetadata(
         string? Name,
+        string? DisplayName,
         string? Summary,
         string? Description,
         EquatableImmutableArray<string>? Tags,

--- a/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.MapAllAttributesAndHttpMethods_MapEndpointHandlers_WithNamespace.verified.txt
+++ b/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.MapAllAttributesAndHttpMethods_MapEndpointHandlers_WithNamespace.verified.txt
@@ -51,6 +51,7 @@ internal static class EndpointRouteBuilderExtensions
 
         builder.MapGet("/complex/{id:int}", static async ([FromServices] global::GeneratedEndpointsTests.ComplexEndpoints handler, [FromRoute] int id, [FromQuery] string filter, [FromHeader(Name = "x-trace-id")] string traceId, [FromBody] global::GeneratedEndpointsTests.GetRequest request, [FromForm] string formValue, [FromServices] IServiceProvider services, [FromKeyedServices("special")] object keyed, [AsParameters] global::GeneratedEndpointsTests.AdditionalParameters parameters, global::System.Threading.CancellationToken cancellationToken) => await handler.GetComplex(id, filter, traceId, request, formValue, services, keyed, parameters, cancellationToken))
             .WithName("GetComplex")
+            .WithDisplayName("Complex data endpoint")
             .WithSummary("Gets complex data.")
             .WithDescription("Uses every supported attribute.")
             .ExcludeFromDescription()

--- a/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.MapAllAttributesAndHttpMethods_MapEndpointHandlers_WithoutNamespace.verified.txt
+++ b/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.MapAllAttributesAndHttpMethods_MapEndpointHandlers_WithoutNamespace.verified.txt
@@ -51,6 +51,7 @@ internal static class EndpointRouteBuilderExtensions
 
         builder.MapGet("/complex/{id:int}", static async ([FromServices] global::ComplexEndpoints handler, [FromRoute] int id, [FromQuery] string filter, [FromHeader(Name = "x-trace-id")] string traceId, [FromBody] global::GetRequest request, [FromForm] string formValue, [FromServices] IServiceProvider services, [FromKeyedServices("special")] object keyed, [AsParameters] global::AdditionalParameters parameters, global::System.Threading.CancellationToken cancellationToken) => await handler.GetComplex(id, filter, traceId, request, formValue, services, keyed, parameters, cancellationToken))
             .WithName("GetComplex")
+            .WithDisplayName("Complex data endpoint")
             .WithSummary("Gets complex data.")
             .WithDescription("Uses every supported attribute.")
             .ExcludeFromDescription()

--- a/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.MapGet_MapEndpointHandlers_WithNamespace.verified.txt
+++ b/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.MapGet_MapEndpointHandlers_WithNamespace.verified.txt
@@ -24,6 +24,7 @@ internal static class EndpointRouteBuilderExtensions
     {
         builder.MapGet("/users/{id:int}", global::GeneratedEndpointsTests.GetUserEndpoint.GetUser2)
             .WithName("GetUser")
+            .WithDisplayName("User lookup endpoint")
             .WithSummary("Gets a user by ID.")
             .WithDescription("Gets a user by ID when the ID is greater than zero.")
             .WithTags("Users");

--- a/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.MapGet_MapEndpointHandlers_WithoutNamespace.verified.txt
+++ b/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.MapGet_MapEndpointHandlers_WithoutNamespace.verified.txt
@@ -24,6 +24,7 @@ internal static class EndpointRouteBuilderExtensions
     {
         builder.MapGet("/users/{id:int}", global::GetUserEndpoint.GetUser2)
             .WithName("GetUser")
+            .WithDisplayName("User lookup endpoint")
             .WithSummary("Gets a user by ID.")
             .WithDescription("Gets a user by ID when the ID is greater than zero.")
             .WithTags("Users");

--- a/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.cs
+++ b/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.cs
@@ -48,7 +48,7 @@ public class GeneratedEndpointsTests
                                              [Tags("Users")]
                                              internal static class GetUserEndpoint
                                              {
-                                                 [MapGet("/users/{id:int}", Name = nameof(GetUser), Summary = "Gets a user by ID.", Description = "Gets a user by ID when the ID is greater than zero.")]
+                                                [MapGet("/users/{id:int}", Name = nameof(GetUser), DisplayName = "User lookup endpoint", Summary = "Gets a user by ID.", Description = "Gets a user by ID when the ID is greater than zero.")]
                                                  public static Results<Ok, NotFound> GetUser2(int id)
                                                  {
                                                      if (id > 0)
@@ -435,7 +435,7 @@ public class GeneratedEndpointsTests
                                                      builder.WithMetadata("configured");
                                                  }
 
-                                                 [MapGet("/complex/{id:int}", Name = nameof(GetComplex), Summary = "Gets complex data.", Description = "Uses every supported attribute.")]
+                                                [MapGet("/complex/{id:int}", Name = nameof(GetComplex), DisplayName = "Complex data endpoint", Summary = "Gets complex data.", Description = "Uses every supported attribute.")]
                                                  [AllowAnonymous]
                                                  [Tags("MethodLevel")]
                                                  [RequireAuthorization("MethodPolicy")]


### PR DESCRIPTION
## Summary
- add support for the `DisplayName` named parameter on HTTP mapping attributes so generated endpoints call `.WithDisplayName`
- document the new capability and extend the tests to cover the new metadata

## Testing
- `dotnet test`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691910dd8cc88328b371ec438575c849)