### PR TITLE
Use component model display metadata attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ GeneratedEndpoints is a .NET source generator that automatically wires Minimal A
 
 GeneratedEndpoints focuses on three goals:
 
-* **Attribute-driven routing** – use `[MapGet]`, `[MapPost]`, `[MapDelete]`, `[MapOptions]`, `[MapHead]`, `[MapPatch]`, `[MapTrace]`, `[MapConnect]`, and even `[MapQuery]` to describe the verb and route pattern. The generator creates the matching `Map*` call and wires up metadata like `.WithName`, `.WithDisplayName`, `.WithSummary`, and `.WithDescription`.
+* **Attribute-driven routing** – use `[MapGet]`, `[MapPost]`, `[MapDelete]`, `[MapOptions]`, `[MapHead]`, `[MapPatch]`, `[MapTrace]`, `[MapConnect]`, and even `[MapQuery]` to describe the verb and route pattern. The generator creates the matching `Map*` call and wires up metadata like `.WithName`, `.WithDisplayName`, `.WithSummary`, and `.WithDescription` (via `[DisplayName]`/`[Description]`).
 * **Feature-first organization** – keep handlers close to the code they execute (for example, alongside your `Todos` feature). Non-static handler classes are automatically registered with dependency injection so you can inject EF Core DbContexts, services, etc.
 * **Metadata composition** – decorate classes and methods with `[Tags]`, `[RequireAuthorization]`, `[DisableAntiforgery]`, `[AllowAnonymous]`, and `[ExcludeFromDescription]`. Apply `[Accepts]`, `[ProducesResponse]`, `[ProducesProblem]`, and `[ProducesValidationProblem]` directly to the methods they describe. Class-level metadata is merged into every method, while method-level metadata can refine or override.
 
@@ -51,6 +51,7 @@ After the reference is added, the source generator contributes its attributes an
 Handlers can be static or instance classes. The following example uses a scoped handler so that EF Core can be injected through the constructor:
 
 ```csharp
+using System.ComponentModel;
 using Microsoft.AspNetCore.Generated.Attributes;
 using Microsoft.AspNetCore.Http.HttpResults;
 
@@ -62,7 +63,9 @@ public sealed class GetTodo
 
     public GetTodo(TodoDbContext db) => _db = db;
 
-    [MapGet("/todos/{id}", Summary = "Retrieve a todo", Description = "Returns the todo matching the provided identifier.")]
+    [DisplayName("Retrieve a todo")]
+    [Description("Returns the todo matching the provided identifier.")]
+    [MapGet("/todos/{id}", Summary = "Retrieve a todo")]
     [Tags("Todos")]
     [RequireAuthorization("Todos.Read")]
     public async Task<Results<Ok<Todo>, NotFound>> HandleAsync(Guid id, CancellationToken cancellationToken)
@@ -76,7 +79,7 @@ public sealed class GetTodo
 Key ideas:
 
 * Choose the attribute that matches the verb (`[MapGet]`, `[MapPost]`, `[MapPut]`, `[MapDelete]`, `[MapPatch]`, `[MapHead]`, `[MapOptions]`, `[MapTrace]`, `[MapConnect]`, `[MapQuery]`).
-* Named arguments like `DisplayName`, `Summary`, `Description`, and `Name` are translated into `.WithDisplayName`, `.WithSummary`, `.WithDescription`, and `.WithName` calls.
+* Named arguments like `Summary` and `Name`, plus `[DisplayName]` and `[Description]`, are translated into `.WithSummary`, `.WithName`, `.WithDisplayName`, and `.WithDescription` calls.
 * Use existing ASP.NET Core binding attributes (`[FromRoute]`, `[FromQuery]`, `[FromBody]`, `[FromHeader]`, `[FromServices]`, `[FromKeyedServices]`, `[AsParameters]`, etc.). The generator preserves them in the produced delegate.
 * Metadata attributes (`[Tags]`, `[RequireAuthorization]`, `[AllowAnonymous]`, `[DisableAntiforgery]`, `[ExcludeFromDescription]`) can be placed on the class, on a method, or on both. Class-level metadata is merged with method-level metadata. Request/response attributes (`[Accepts]`, `[ProducesResponse]`, `[ProducesProblem]`, `[ProducesValidationProblem]`) must be applied directly to the method they describe.
 
@@ -248,7 +251,7 @@ public sealed class CreateTodo
 
 | Attribute | Scope | Purpose |
 | --- | --- | --- |
-| `[MapGet]`, `[MapPost]`, `[MapPut]`, `[MapDelete]`, `[MapPatch]`, `[MapHead]`, `[MapOptions]`, `[MapTrace]`, `[MapConnect]`, `[MapQuery]` | Method | Declares an endpoint and its route pattern. Named arguments fill the generated `.WithName`, `.WithDisplayName`, `.WithSummary`, and `.WithDescription` calls. |
+| `[MapGet]`, `[MapPost]`, `[MapPut]`, `[MapDelete]`, `[MapPatch]`, `[MapHead]`, `[MapOptions]`, `[MapTrace]`, `[MapConnect]`, `[MapQuery]` | Method | Declares an endpoint and its route pattern. Named arguments fill the generated `.WithName` and `.WithSummary` calls while `[DisplayName]`/`[Description]` add `.WithDisplayName`/`.WithDescription`. |
 | `[Tags]` | Class or method | Adds tags to one or more endpoints. Multiple attributes merge without duplication. |
 | `[RequireAuthorization]` | Class or method | Requires authorization for the endpoint. Passing policies (`[RequireAuthorization("Todos.Read", "Todos.Write")]`) emits `.RequireAuthorization("Todos.Read", "Todos.Write")`. |
 | `[AllowAnonymous]` | Class or method | Explicitly opts an endpoint into anonymous access, overriding `[RequireAuthorization]`. |

--- a/src/GeneratedEndpoints/MinimalApiGenerator.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.cs
@@ -19,6 +19,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
     private static readonly string[] AspNetCoreHttpNamespaceParts = new[] { "Microsoft", "AspNetCore", "Http" };
     private static readonly string[] AspNetCoreAuthorizationNamespaceParts = new[] { "Microsoft", "AspNetCore", "Authorization" };
     private static readonly string[] AspNetCoreRoutingNamespaceParts = new[] { "Microsoft", "AspNetCore", "Routing" };
+    private static readonly string[] ComponentModelNamespaceParts = new[] { "System", "ComponentModel" };
 
     private const string FallbackHttpMethod = "__FALLBACK__";
 
@@ -41,9 +42,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         HttpAttributeDefinitions.ToImmutableDictionary(static definition => definition.Name);
 
     private const string NameAttributeNamedParameter = "Name";
-    private const string DisplayNameAttributeNamedParameter = "DisplayName";
     private const string SummaryAttributeNamedParameter = "Summary";
-    private const string DescriptionAttributeNamedParameter = "Description";
     private const string ResponseTypeAttributeNamedParameter = "ResponseType";
     private const string RequestTypeAttributeNamedParameter = "RequestType";
     private const string IsOptionalAttributeNamedParameter = "IsOptional";
@@ -808,19 +807,9 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                      public string Name { get; set; } = "";
 
                      /// <summary>
-                     /// Gets or sets the endpoint display name.
-                     /// </summary>
-                     public string DisplayName { get; set; } = "";
-
-                     /// <summary>
                      /// Gets or sets the endpoint summary.
                      /// </summary>
                      public string Summary { get; set; } = "";
-
-                     /// <summary>
-                     /// Gets or sets the endpoint description.
-                     /// </summary>
-                     public string Description { get; set; } = "";
 
                      /// <summary>
                      /// Initializes a new instance of the <see cref="{{attributeName}}"/> class.
@@ -857,7 +846,9 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
 
         var requestHandlerMethod = GetRequestHandlerMethod(requestHandlerMethodSymbol, cancellationToken);
 
-        var (httpMethod, pattern, name, displayName, summary, description) = GetRequestHandlerAttribute(attribute, cancellationToken);
+        var (httpMethod, pattern, name, summary) = GetRequestHandlerAttribute(attribute, cancellationToken);
+
+        var (displayName, description) = GetDisplayAndDescriptionAttributes(requestHandlerMethodSymbol);
 
         var (tags, requireAuthorization, authorizationPolicies, disableAntiforgery, allowAnonymous, excludeFromDescription,
                 accepts, produces, producesProblem, producesValidationProblem, requireCors, corsPolicyName, requiredHosts, requireRateLimiting,
@@ -901,9 +892,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         string HttpMethod,
         string Pattern,
         string? Name,
-        string? DisplayName,
-        string? Summary,
-        string? Description
+        string? Summary
     ) GetRequestHandlerAttribute(
         AttributeData attribute,
         CancellationToken cancellationToken
@@ -920,9 +909,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         var pattern = (attribute.ConstructorArguments.Length > 0 ? attribute.ConstructorArguments[0].Value as string : "") ?? "";
 
         string? name = null;
-        string? displayName = null;
         string? summary = null;
-        string? description = null;
         foreach (var namedArg in attribute.NamedArguments)
         {
             switch (namedArg.Key)
@@ -933,28 +920,47 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                     name = string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
                     break;
                 }
-                case DisplayNameAttributeNamedParameter:
-                {
-                    var value = namedArg.Value.Value as string;
-                    displayName = string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
-                    break;
-                }
                 case SummaryAttributeNamedParameter:
                 {
                     var value = namedArg.Value.Value as string;
                     summary = string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
                     break;
                 }
-                case DescriptionAttributeNamedParameter:
-                {
-                    var value = namedArg.Value.Value as string;
-                    description = string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
-                    break;
-                }
             }
         }
 
-        return (httpMethod, pattern, name, displayName, summary, description);
+        return (httpMethod, pattern, name, summary);
+    }
+
+    private static (string? DisplayName, string? Description) GetDisplayAndDescriptionAttributes(IMethodSymbol methodSymbol)
+    {
+        string? displayName = null;
+        string? description = null;
+
+        foreach (var attribute in methodSymbol.GetAttributes())
+        {
+            var attributeClass = attribute.AttributeClass;
+            if (attributeClass is null)
+                continue;
+
+            if (IsAttribute(attributeClass, nameof(System.ComponentModel.DisplayNameAttribute), ComponentModelNamespaceParts))
+            {
+                displayName = NormalizeOptionalString(attribute.ConstructorArguments.Length > 0
+                    ? attribute.ConstructorArguments[0].Value as string
+                    : null);
+
+                continue;
+            }
+
+            if (IsAttribute(attributeClass, nameof(System.ComponentModel.DescriptionAttribute), ComponentModelNamespaceParts))
+            {
+                description = NormalizeOptionalString(attribute.ConstructorArguments.Length > 0
+                    ? attribute.ConstructorArguments[0].Value as string
+                    : null);
+            }
+        }
+
+        return (displayName, description);
     }
 
     private static (

--- a/tests/GeneratedEndpoints.Tests.Lab/GetUserEndpoint.cs
+++ b/tests/GeneratedEndpoints.Tests.Lab/GetUserEndpoint.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Generated.Attributes;
@@ -26,7 +27,9 @@ internal sealed class GetUserEndpoint(IServiceProvider serviceProvider)
     [ProducesResponse<UserProfile>(StatusCodes.Status202Accepted, "application/json")]
     [ProducesProblem(StatusCodes.Status500InternalServerError, "application/problem+json")]
     [ProducesValidationProblem(StatusCodes.Status400BadRequest, "application/problem+json")]
-    [MapGet("/users/{id:int}", Name = nameof(GetUser), Summary = "Gets a user by ID.", Description = "Gets a user by ID when the ID is greater than zero.")]
+    [DisplayName("User lookup endpoint")]
+    [Description("Gets a user by ID when the ID is greater than zero.")]
+    [MapGet("/users/{id:int}", Name = nameof(GetUser), Summary = "Gets a user by ID.")]
     public Results<Ok<UserProfile>, NotFound, ValidationProblem, ProblemHttpResult> GetUser(
         [FromQuery] int id,
         [FromKeyedServices(ServiceLifetime.Scoped)] IServiceCollection services

--- a/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.cs
+++ b/tests/GeneratedEndpoints.Tests/GeneratedEndpointsTests.cs
@@ -48,7 +48,9 @@ public class GeneratedEndpointsTests
                                              [Tags("Users")]
                                              internal static class GetUserEndpoint
                                              {
-                                                [MapGet("/users/{id:int}", Name = nameof(GetUser), DisplayName = "User lookup endpoint", Summary = "Gets a user by ID.", Description = "Gets a user by ID when the ID is greater than zero.")]
+                                                [System.ComponentModel.DisplayName("User lookup endpoint")]
+                                                [System.ComponentModel.Description("Gets a user by ID when the ID is greater than zero.")]
+                                                [MapGet("/users/{id:int}", Name = nameof(GetUser), Summary = "Gets a user by ID.")]
                                                  public static Results<Ok, NotFound> GetUser2(int id)
                                                  {
                                                      if (id > 0)
@@ -494,7 +496,9 @@ public class GeneratedEndpointsTests
                                                      builder.WithMetadata("configured");
                                                  }
 
-                                                [MapGet("/complex/{id:int}", Name = nameof(GetComplex), DisplayName = "Complex data endpoint", Summary = "Gets complex data.", Description = "Uses every supported attribute.")]
+                                                [System.ComponentModel.DisplayName("Complex data endpoint")]
+                                                [System.ComponentModel.Description("Uses every supported attribute.")]
+                                                [MapGet("/complex/{id:int}", Name = nameof(GetComplex), Summary = "Gets complex data.")]
                                                  [AllowAnonymous]
                                                  [Tags("MethodLevel")]
                                                  [RequireAuthorization("MethodPolicy")]


### PR DESCRIPTION
## Summary
- read display name and description metadata from `System.ComponentModel` attributes instead of named parameters on the generated map attributes
- update docs, sample code, and tests to apply `[DisplayName]`/`[Description]` and remove the obsolete named parameters

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691917358f5c83289001b870c228e15f)