### PR TITLE
Use MapGroup Name parameter for endpoint group names

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,10 @@ applied to all endpoints within the class.
 * `[EndpointFilter(Type filterType)]`
 * `[EndpointFilter<TFilter>]`
 * `[ExcludeFromDescription]`
-* `[GroupName(string name)]`
 * `[MapConnect(string pattern = "", Name = null)]`
 * `[MapDelete(string pattern = "", Name = null)]`
 * `[MapFallback(string pattern = "", Name = null)]`
-* `[MapGroup(string pattern)]`
+* `[MapGroup(string pattern, Name = null)]`
 * `[MapGet(string pattern = "", Name = null)]`
 * `[MapHead(string pattern = "", Name = null)]`
 * `[MapOptions(string pattern = "", Name = null)]`

--- a/src/GeneratedEndpoints/MinimalApiGenerator.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.cs
@@ -60,10 +60,6 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
     private const string OrderAttributeFullyQualifiedName = $"{AttributesNamespace}.{OrderAttributeName}";
     private const string OrderAttributeHint = $"{OrderAttributeFullyQualifiedName}.gs.cs";
 
-    private const string GroupNameAttributeName = "GroupNameAttribute";
-    private const string GroupNameAttributeFullyQualifiedName = $"{AttributesNamespace}.{GroupNameAttributeName}";
-    private const string GroupNameAttributeHint = $"{GroupNameAttributeFullyQualifiedName}.gs.cs";
-
     private const string MapGroupAttributeName = "MapGroupAttribute";
     private const string MapGroupAttributeFullyQualifiedName = $"{AttributesNamespace}.{MapGroupAttributeName}";
     private const string MapGroupAttributeHint = $"{MapGroupAttributeFullyQualifiedName}.gs.cs";
@@ -446,36 +442,6 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                             """;
         context.AddSource(OrderAttributeHint, SourceText.From(orderSource, Encoding.UTF8));
 
-        // GroupName
-        var groupNameSource = $$"""
-                                {{FileHeader}}
-
-                                namespace {{AttributesNamespace}};
-
-                                /// <summary>
-                                /// Specifies the endpoint group name for the annotated class.
-                                /// </summary>
-                                [global::System.AttributeUsage(global::System.AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
-                                internal sealed class {{GroupNameAttributeName}} : global::System.Attribute
-                                {
-                                    /// <summary>
-                                    /// Gets the endpoint group name.
-                                    /// </summary>
-                                    public string GroupName { get; }
-
-                                    /// <summary>
-                                    /// Initializes a new instance of the <see cref="{{GroupNameAttributeName}}"/> class.
-                                    /// </summary>
-                                    /// <param name="groupName">The endpoint group name to apply.</param>
-                                    public {{GroupNameAttributeName}}(string groupName)
-                                    {
-                                        GroupName = groupName;
-                                    }
-                                }
-
-                                """;
-        context.AddSource(GroupNameAttributeHint, SourceText.From(groupNameSource, Encoding.UTF8));
-
         // MapGroup
         var mapGroupSource = $$"""
                                {{FileHeader}}
@@ -492,6 +458,11 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                                    /// Gets the route group pattern.
                                    /// </summary>
                                    public string Pattern { get; }
+
+                                   /// <summary>
+                                   /// Gets or sets the endpoint group name.
+                                   /// </summary>
+                                   public string? Name { get; set; }
 
                                    /// <summary>
                                    /// Initializes a new instance of the <see cref="{{MapGroupAttributeName}}"/> class.
@@ -1110,14 +1081,11 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                 continue;
             }
 
-            if (IsGeneratedAttribute(attributeClass, GroupNameAttributeName))
+            if (IsGeneratedAttribute(attributeClass, MapGroupAttributeName))
             {
-                if (attribute.ConstructorArguments.Length > 0)
-                {
-                    var groupName = NormalizeOptionalString(attribute.ConstructorArguments[0].Value as string);
-                    if (!string.IsNullOrEmpty(groupName))
-                        endpointGroupName = groupName;
-                }
+                var groupName = GetNamedStringValue(attribute, NameAttributeNamedParameter);
+                if (!string.IsNullOrEmpty(groupName))
+                    endpointGroupName = groupName;
 
                 continue;
             }
@@ -1324,9 +1292,9 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
 
             if (attribute.ConstructorArguments.Length > 0)
             {
-                var pattern = NormalizeOptionalString(attribute.ConstructorArguments[0].Value as string);
-                if (!string.IsNullOrEmpty(pattern))
-                    return pattern;
+                var pattern = attribute.ConstructorArguments[0].Value as string;
+                if (pattern is not null)
+                    return pattern.Trim();
             }
         }
 
@@ -1993,7 +1961,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         source.AppendLine("    {");
 
         var groupedClasses = requestHandlers.Select(static handler => handler.Class)
-            .Where(static handlerClass => !string.IsNullOrEmpty(handlerClass.MapGroupPattern))
+            .Where(static handlerClass => handlerClass.MapGroupPattern is not null)
             .Distinct()
             .ToArray();
 

--- a/tests/GeneratedEndpoints.Tests/Common/SourceFactory.cs
+++ b/tests/GeneratedEndpoints.Tests/Common/SourceFactory.cs
@@ -81,14 +81,22 @@ public static class SourceFactory
             builder.AppendLine($"[RequireCors{cors}]");
         }
 
-        if (!string.IsNullOrWhiteSpace(groupName))
+        if (!string.IsNullOrWhiteSpace(groupName) && mapGroupPattern is null)
         {
-            builder.AppendLine($"[GroupName(\"{groupName}\")]");
+            mapGroupPattern = string.Empty;
         }
 
-        if (!string.IsNullOrWhiteSpace(mapGroupPattern))
+        if (mapGroupPattern is not null)
         {
-            builder.AppendLine($"[MapGroup(\"{mapGroupPattern}\")]");
+            var mapGroupAttribute = new StringBuilder();
+            mapGroupAttribute.Append($"[MapGroup(\"{mapGroupPattern}\"");
+            if (!string.IsNullOrWhiteSpace(groupName))
+            {
+                mapGroupAttribute.Append($", Name = \"{groupName}\"");
+            }
+
+            mapGroupAttribute.Append(")]");
+            builder.AppendLine(mapGroupAttribute.ToString());
         }
 
         if (applyShortCircuit)

--- a/tests/GeneratedEndpoints.Tests/GeneratedSourceTests.AuthorizationAndMetadataMatrix_257E8A8FA30F_MapEndpointHandlers.verified.txt
+++ b/tests/GeneratedEndpoints.Tests/GeneratedSourceTests.AuthorizationAndMetadataMatrix_257E8A8FA30F_MapEndpointHandlers.verified.txt
@@ -23,18 +23,21 @@ internal static class EndpointRouteBuilderExtensions
 {
     internal static IEndpointRouteBuilder MapEndpointHandlers(this IEndpointRouteBuilder builder)
     {
-        builder.MapGet("/matrix/{id:int}", global::GeneratedEndpointsTests.AuthorizationMatrixEndpoints.Handle)
-            .WithName("GetMatrix")
+        var _GeneratedEndpointsTests_AuthorizationMatrixEndpoints_Group = builder.MapGroup("")
             .WithGroupName("Docs")
             .WithOrder(-5)
             .ExcludeFromDescription()
+            .RequireCors()
+            .RequireHost("api.alt.com")
+            .DisableRequestTimeout();
+
+        _GeneratedEndpointsTests_AuthorizationMatrixEndpoints_Group.MapGet("/matrix/{id:int}", global::GeneratedEndpointsTests.AuthorizationMatrixEndpoints.Handle)
+            .WithName("GetMatrix")
             .WithTags("Method", "Matrix")
             .RequireAuthorization("MethodPolicy")
             .RequireCors("MethodCors")
-            .RequireHost("api.alt.com")
             .RequireRateLimiting("BurstPolicy")
-            .AllowAnonymous()
-            .DisableRequestTimeout();
+            .AllowAnonymous();
 
         return builder;
     }

--- a/tests/GeneratedEndpoints.Tests/GeneratedSourceTests.AuthorizationAndMetadataMatrix_25B2AC35B582_MapEndpointHandlers.verified.txt
+++ b/tests/GeneratedEndpoints.Tests/GeneratedSourceTests.AuthorizationAndMetadataMatrix_25B2AC35B582_MapEndpointHandlers.verified.txt
@@ -23,19 +23,23 @@ internal static class EndpointRouteBuilderExtensions
 {
     internal static IEndpointRouteBuilder MapEndpointHandlers(this IEndpointRouteBuilder builder)
     {
-        builder.MapGet("/matrix/{id:int}", global::GeneratedEndpointsTests.AuthorizationMatrixEndpoints.Handle)
-            .WithName("GetMatrix")
+        var _GeneratedEndpointsTests_AuthorizationMatrixEndpoints_Group = builder.MapGroup("")
             .WithGroupName("Reporting")
             .WithOrder(5)
             .ExcludeFromDescription()
-            .WithTags("Class", "Matrix", "Method")
+            .WithTags("Class", "Matrix")
             .RequireAuthorization("ClassPolicy")
             .RequireCors("NamedCorsPolicy")
-            .RequireHost("*.contoso.com", "api.contoso.com", "contoso.com")
-            .RequireRateLimiting("RatePolicy")
+            .RequireHost("*.contoso.com")
             .AllowAnonymous()
             .ShortCircuit()
             .WithRequestTimeout("TimeoutPolicy");
+
+        _GeneratedEndpointsTests_AuthorizationMatrixEndpoints_Group.MapGet("/matrix/{id:int}", global::GeneratedEndpointsTests.AuthorizationMatrixEndpoints.Handle)
+            .WithName("GetMatrix")
+            .WithTags("Method", "Matrix")
+            .RequireHost("api.contoso.com", "contoso.com")
+            .RequireRateLimiting("RatePolicy");
 
         return builder;
     }

--- a/tests/GeneratedEndpoints.Tests/GeneratedSourceTests.AuthorizationAndMetadataMatrix_4F441534B0BD_MapEndpointHandlers.verified.txt
+++ b/tests/GeneratedEndpoints.Tests/GeneratedSourceTests.AuthorizationAndMetadataMatrix_4F441534B0BD_MapEndpointHandlers.verified.txt
@@ -22,16 +22,21 @@ internal static class EndpointRouteBuilderExtensions
 {
     internal static IEndpointRouteBuilder MapEndpointHandlers(this IEndpointRouteBuilder builder)
     {
-        builder.MapGet("/matrix/{id:int}", global::GeneratedEndpointsTests.AuthorizationMatrixEndpoints.Handle)
-            .WithName("GetMatrix")
+        var _GeneratedEndpointsTests_AuthorizationMatrixEndpoints_Group = builder.MapGroup("")
             .WithGroupName("Operations")
             .ExcludeFromDescription()
             .WithTags("Class", "Matrix")
-            .RequireAuthorization("ClassPolicy", "MethodPolicy")
+            .RequireAuthorization("ClassPolicy")
             .RequireCors()
             .RequireHost("*.example.com")
             .AllowAnonymous()
             .DisableRequestTimeout();
+
+        _GeneratedEndpointsTests_AuthorizationMatrixEndpoints_Group.MapGet("/matrix/{id:int}", global::GeneratedEndpointsTests.AuthorizationMatrixEndpoints.Handle)
+            .WithName("GetMatrix")
+            .RequireAuthorization("MethodPolicy")
+            .RequireCors()
+            .AllowAnonymous();
 
         return builder;
     }

--- a/tests/GeneratedEndpoints.Tests/IndividualTests.GroupName_MapEndpointHandlers.verified.txt
+++ b/tests/GeneratedEndpoints.Tests/IndividualTests.GroupName_MapEndpointHandlers.verified.txt
@@ -22,9 +22,11 @@ internal static class EndpointRouteBuilderExtensions
 {
     internal static IEndpointRouteBuilder MapEndpointHandlers(this IEndpointRouteBuilder builder)
     {
-        builder.MapGet("/matrix/{id:int}", global::GeneratedEndpointsTests.AuthorizationMatrixEndpoints.Handle)
-            .WithName("GetMatrix")
+        var _GeneratedEndpointsTests_AuthorizationMatrixEndpoints_Group = builder.MapGroup("")
             .WithGroupName("IndividualGroup");
+
+        _GeneratedEndpointsTests_AuthorizationMatrixEndpoints_Group.MapGet("/matrix/{id:int}", global::GeneratedEndpointsTests.AuthorizationMatrixEndpoints.Handle)
+            .WithName("GetMatrix");
 
         return builder;
     }


### PR DESCRIPTION
## Summary
- remove the standalone GroupName attribute and extend MapGroup with an optional Name property so group metadata is applied at the group level
- update the generator, README, and test source factory to honor the new parameter (including allowing empty map-group patterns)
- refresh the affected snapshot baselines to reflect the new MapGroup-based group naming behavior

## Testing
- `dotnet test`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691948698bf483288a3205940d437c51)