### PR TITLE
Optimize source generator performance

### DIFF
--- a/src/GeneratedEndpoints/Common/StringBuilderPool.cs
+++ b/src/GeneratedEndpoints/Common/StringBuilderPool.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Text;
+
+namespace GeneratedEndpoints.Common;
+
+/// <summary>Provides a simple per-thread cache for <see cref="StringBuilder"/> instances.</summary>
+internal static class StringBuilderPool
+{
+    private const int MaxBuilderCapacity = 128 * 1024;
+
+    [ThreadStatic]
+    private static StringBuilder? _cachedInstance;
+
+    /// <summary>Gets a <see cref="StringBuilder"/> with at least the requested capacity.</summary>
+    public static StringBuilder Get(int capacity = 16)
+    {
+        var builder = _cachedInstance;
+        if (builder is null)
+            return new StringBuilder(capacity);
+
+        _cachedInstance = null;
+        builder.Clear();
+        if (builder.Capacity < capacity)
+            builder.EnsureCapacity(capacity);
+
+        return builder;
+    }
+
+    /// <summary>Returns the <see cref="StringBuilder"/> to the pool if it is below the maximum retention size.</summary>
+    public static void Return(StringBuilder builder)
+    {
+        if (builder.Capacity > MaxBuilderCapacity)
+            return;
+
+        builder.Clear();
+        if (_cachedInstance is null)
+            _cachedInstance = builder;
+    }
+
+    /// <summary>Converts the builder to a string and returns it to the pool.</summary>
+    public static string ToStringAndReturn(StringBuilder builder)
+    {
+        var result = builder.ToString();
+        Return(builder);
+        return result;
+    }
+}

--- a/src/GeneratedEndpoints/MinimalApiGenerator.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.cs
@@ -153,6 +153,612 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                                                  #nullable enable
                                                  """;
 
+    private static readonly SourceText RequireAuthorizationAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Specifies that authorization is required for the annotated endpoint or class.
+        /// Optionally restricts access to the specified authorization policies.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+        internal sealed class {{RequireAuthorizationAttributeName}} : global::System.Attribute
+        {
+            /// <summary>
+            /// Gets the policy names that the endpoint or class requires.
+            /// </summary>
+            public string[] PolicyNames { get; }
+
+            /// <summary>
+            /// Marks the endpoint or class as requiring authorization.
+            /// </summary>
+            public {{RequireAuthorizationAttributeName}}()
+            {
+                PolicyNames = [];
+            }
+
+            /// <summary>
+            /// Marks the endpoint or class as requiring authorization with one or more policies.
+            /// </summary>
+            public {{RequireAuthorizationAttributeName}}(params string[] policyNames)
+            {
+                PolicyNames = policyNames ?? [];
+            }
+        }
+        """, Encoding.UTF8);
+
+    private static readonly SourceText RequireCorsAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Specifies that the annotated endpoint requires a configured CORS policy.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+        internal sealed class {{RequireCorsAttributeName}} : global::System.Attribute
+        {
+            /// <summary>
+            /// Gets the optional CORS policy name.
+            /// </summary>
+            public string? PolicyName { get; }
+
+            /// <summary>
+            /// Marks the endpoint or class as requiring the default CORS policy.
+            /// </summary>
+            public {{RequireCorsAttributeName}}()
+            {
+            }
+
+            /// <summary>
+            /// Marks the endpoint or class as requiring the specified named CORS policy.
+            /// </summary>
+            public {{RequireCorsAttributeName}}(string policyName)
+            {
+                PolicyName = policyName;
+            }
+        }
+        """, Encoding.UTF8);
+
+    private static readonly SourceText RequireRateLimitingAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Specifies that the annotated endpoint requires the provided rate limiting policy.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+        internal sealed class {{RequireRateLimitingAttributeName}} : global::System.Attribute
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="{{RequireRateLimitingAttributeName}}"/> class.
+            /// </summary>
+            /// <param name="policyName">The rate limiting policy to apply.</param>
+            public {{RequireRateLimitingAttributeName}}(string policyName)
+            {
+                PolicyName = policyName;
+            }
+
+            /// <summary>
+            /// Gets the rate limiting policy name.
+            /// </summary>
+            public string PolicyName { get; }
+        }
+        """, Encoding.UTF8);
+
+    private static readonly SourceText RequireHostAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Specifies the allowed hosts for the annotated endpoint or class.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+        internal sealed class {{RequireHostAttributeName}} : global::System.Attribute
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="{{RequireHostAttributeName}}"/> class.
+            /// </summary>
+            /// <param name="hosts">The hosts that are allowed to access the endpoint.</param>
+            public {{RequireHostAttributeName}}(params string[] hosts)
+            {
+                Hosts = hosts ?? [];
+            }
+
+            /// <summary>
+            /// Gets the allowed hosts.
+            /// </summary>
+            public string[] Hosts { get; }
+        }
+        """, Encoding.UTF8);
+
+    private static readonly SourceText DisableAntiforgeryAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Disables antiforgery protection for the annotated endpoint or class.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+        internal sealed class {{DisableAntiforgeryAttributeName}} : global::System.Attribute
+        {
+        }
+
+        """, Encoding.UTF8);
+
+    private static readonly SourceText ShortCircuitAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Marks the annotated endpoint or class to short-circuit the request pipeline.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+        internal sealed class {{ShortCircuitAttributeName}} : global::System.Attribute
+        {
+        }
+
+        """, Encoding.UTF8);
+
+    private static readonly SourceText DisableRequestTimeoutAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Disables the request timeout for the annotated endpoint or class.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+        internal sealed class {{DisableRequestTimeoutAttributeName}} : global::System.Attribute
+        {
+        }
+
+        """, Encoding.UTF8);
+
+    private static readonly SourceText DisableValidationAttributeSourceText = SourceText.From(
+$$"""
+#if NET10_0_OR_GREATER
+{{FileHeader}}
+
+namespace {{AttributesNamespace}};
+
+/// <summary>
+/// Disables request validation for the annotated endpoint or class when targeting .NET 10 or later.
+/// </summary>
+[global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+internal sealed class {{DisableValidationAttributeName}} : global::System.Attribute
+{
+}
+#endif
+
+""", Encoding.UTF8);
+
+    private static readonly SourceText RequestTimeoutAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Applies the request timeout metadata to the annotated endpoint or class.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+        internal sealed class {{RequestTimeoutAttributeName}} : global::System.Attribute
+        {
+            /// <summary>
+            /// Gets the optional request timeout policy name.
+            /// </summary>
+            public string? PolicyName { get; init; }
+
+            /// <summary>
+            /// Applies the default request timeout behavior.
+            /// </summary>
+            public {{RequestTimeoutAttributeName}}()
+            {
+            }
+
+            /// <summary>
+            /// Applies the specified request timeout policy.
+            /// </summary>
+            /// <param name="policyName">The request timeout policy name.</param>
+            public {{RequestTimeoutAttributeName}}(string policyName)
+            {
+                PolicyName = policyName;
+            }
+        }
+
+        """, Encoding.UTF8);
+
+    private static readonly SourceText OrderAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Specifies the order for the annotated endpoint when building conventions.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+        internal sealed class {{OrderAttributeName}} : global::System.Attribute
+        {
+            /// <summary>
+            /// Gets the order that will be applied to the endpoint.
+            /// </summary>
+            public int Order { get; }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="{{OrderAttributeName}}"/> class.
+            /// </summary>
+            /// <param name="order">The order value to apply to the endpoint.</param>
+            public {{OrderAttributeName}}(int order)
+            {
+                Order = order;
+            }
+        }
+
+        """, Encoding.UTF8);
+
+    private static readonly SourceText MapGroupAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Specifies the route group for the annotated class.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+        internal sealed class {{MapGroupAttributeName}} : global::System.Attribute
+        {
+            /// <summary>
+            /// Gets the route group pattern.
+            /// </summary>
+            public string Pattern { get; }
+
+            /// <summary>
+            /// Gets or sets the endpoint group name.
+            /// </summary>
+            public string? Name { get; init; }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="{{MapGroupAttributeName}}"/> class.
+            /// </summary>
+            /// <param name="pattern">The route group pattern to apply.</param>
+            public {{MapGroupAttributeName}}(string pattern)
+            {
+                Pattern = pattern;
+            }
+        }
+
+        """, Encoding.UTF8);
+
+    private static readonly SourceText SummaryAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Specifies the summary metadata for the annotated endpoint.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+        internal sealed class {{SummaryAttributeName}} : global::System.Attribute
+        {
+            /// <summary>
+            /// Gets the summary value for the endpoint.
+            /// </summary>
+            public string Summary { get; }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="{{SummaryAttributeName}}"/> class.
+            /// </summary>
+            /// <param name="summary">The summary to apply to the endpoint.</param>
+            public {{SummaryAttributeName}}(string summary)
+            {
+                Summary = summary;
+            }
+        }
+
+        """, Encoding.UTF8);
+
+    private static readonly SourceText AcceptsAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Specifies the request type and content types accepted by the annotated endpoint or class.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+        internal sealed class {{AcceptsAttributeName}} : global::System.Attribute
+        {
+            /// <summary>
+            /// Gets the request type accepted by the endpoint.
+            /// </summary>
+            public global::System.Type? RequestType { get; init; }
+
+            /// <summary>
+            /// Gets a value indicating whether the request body is optional.
+            /// </summary>
+            public bool IsOptional { get; init; }
+
+            /// <summary>
+            /// Gets the primary content type accepted by the endpoint.
+            /// </summary>
+            public string ContentType { get; }
+
+            /// <summary>
+            /// Gets the additional content types accepted by the endpoint.
+            /// </summary>
+            public string[] AdditionalContentTypes { get; }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="{{AcceptsAttributeName}}"/> class.
+            /// </summary>
+            /// <param name="contentType">The primary content type accepted by the endpoint.</param>
+            /// <param name="additionalContentTypes">Additional content types accepted by the endpoint.</param>
+            public {{AcceptsAttributeName}}(string contentType = "application/json", params string[] additionalContentTypes)
+            {
+                ContentType = string.IsNullOrWhiteSpace(contentType) ? "application/json" : contentType;
+                AdditionalContentTypes = additionalContentTypes ?? [];
+            }
+        }
+
+        /// <summary>
+        /// Specifies the request type using a generic argument and the content types accepted by the annotated endpoint or class.
+        /// </summary>
+        /// <typeparam name="TRequest">The CLR type of the request body.</typeparam>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+        internal sealed class {{AcceptsAttributeName}}<TRequest> : global::System.Attribute
+        {
+            /// <summary>
+            /// Gets the request type accepted by the endpoint.
+            /// </summary>
+            public global::System.Type RequestType => typeof(TRequest);
+
+            /// <summary>
+            /// Gets a value indicating whether the request body is optional.
+            /// </summary>
+            public bool IsOptional { get; init; }
+
+            /// <summary>
+            /// Gets the primary content type accepted by the endpoint.
+            /// </summary>
+            public string ContentType { get; }
+
+            /// <summary>
+            /// Gets the additional content types accepted by the endpoint.
+            /// </summary>
+            public string[] AdditionalContentTypes { get; }
+
+            /// <summary>
+            /// Initializes a new instance of the generic Accepts attribute class.
+            /// </summary>
+            /// <param name="contentType">The primary content type accepted by the endpoint.</param>
+            /// <param name="additionalContentTypes">Additional content types accepted by the endpoint.</param>
+            public {{AcceptsAttributeName}}(string contentType = "application/json", params string[] additionalContentTypes)
+            {
+                ContentType = string.IsNullOrWhiteSpace(contentType) ? "application/json" : contentType;
+                AdditionalContentTypes = additionalContentTypes ?? [];
+            }
+        }
+
+        """, Encoding.UTF8);
+
+    private static readonly SourceText EndpointFilterAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Specifies an endpoint filter type to apply to the annotated endpoint or class.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+        internal sealed class {{EndpointFilterAttributeName}} : global::System.Attribute
+        {
+            /// <summary>
+            /// Gets the CLR type of the endpoint filter.
+            /// </summary>
+            public global::System.Type FilterType { get; }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="{{EndpointFilterAttributeName}}"/> class.
+            /// </summary>
+            /// <param name="filterType">The CLR type of the endpoint filter.</param>
+            public {{EndpointFilterAttributeName}}(global::System.Type filterType)
+            {
+                FilterType = filterType ?? throw new global::System.ArgumentNullException(nameof(filterType));
+            }
+        }
+
+        /// <summary>
+        /// Specifies an endpoint filter type using a generic argument.
+        /// </summary>
+        /// <typeparam name="TFilter">The CLR type of the endpoint filter.</typeparam>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+        internal sealed class {{EndpointFilterAttributeName}}<TFilter> : global::System.Attribute
+        {
+            /// <summary>
+            /// Gets the CLR type of the endpoint filter.
+            /// </summary>
+            public global::System.Type FilterType => typeof(TFilter);
+        }
+
+        """, Encoding.UTF8);
+
+    private static readonly SourceText ProducesResponseAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Specifies a response type, status code, and content types produced by the annotated endpoint or class.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+        internal sealed class {{ProducesResponseAttributeName}} : global::System.Attribute
+        {
+        /// <summary>
+        /// Gets the response type produced by the endpoint.
+        /// </summary>
+        public global::System.Type? ResponseType { get; init; }
+
+            /// <summary>
+            /// Gets the HTTP status code returned by the endpoint.
+            /// </summary>
+            public int StatusCode { get; }
+
+            /// <summary>
+            /// Gets the primary content type produced by the endpoint.
+            /// </summary>
+            public string? ContentType { get; }
+
+            /// <summary>
+            /// Gets the additional content types produced by the endpoint.
+            /// </summary>
+            public string[] AdditionalContentTypes { get; }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="{{ProducesResponseAttributeName}}"/> class.
+            /// </summary>
+            /// <param name="statusCode">The HTTP status code returned by the endpoint.</param>
+            /// <param name="contentType">The primary content type produced by the endpoint.</param>
+            /// <param name="additionalContentTypes">Additional content types produced by the endpoint.</param>
+            public {{ProducesResponseAttributeName}}(int statusCode = global::Microsoft.AspNetCore.Http.StatusCodes.Status200OK, string? contentType = null, params string[] additionalContentTypes)
+            {
+                StatusCode = statusCode;
+                ContentType = contentType;
+                AdditionalContentTypes = additionalContentTypes ?? [];
+            }
+        }
+
+        /// <summary>
+        /// Specifies a response type using a generic argument along with status code and content types produced by the annotated endpoint or class.
+        /// </summary>
+        /// <typeparam name="TResponse">The CLR type of the response body.</typeparam>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+        internal sealed class {{ProducesResponseAttributeName}}<TResponse> : global::System.Attribute
+        {
+            /// <summary>
+            /// Gets the response type produced by the endpoint.
+            /// </summary>
+            public global::System.Type ResponseType => typeof(TResponse);
+
+            /// <summary>
+            /// Gets the HTTP status code returned by the endpoint.
+            /// </summary>
+            public int StatusCode { get; }
+
+            /// <summary>
+            /// Gets the primary content type produced by the endpoint.
+            /// </summary>
+            public string? ContentType { get; }
+
+            /// <summary>
+            /// Gets the additional content types produced by the endpoint.
+            /// </summary>
+            public string[] AdditionalContentTypes { get; }
+
+            /// <summary>
+            /// Initializes a new instance of the generic Produces attribute class.
+            /// </summary>
+            /// <param name="statusCode">The HTTP status code returned by the endpoint.</param>
+            /// <param name="contentType">The primary content type produced by the endpoint.</param>
+            /// <param name="additionalContentTypes">Additional content types produced by the endpoint.</param>
+            public {{ProducesResponseAttributeName}}(int statusCode = global::Microsoft.AspNetCore.Http.StatusCodes.Status200OK, string? contentType = null, params string[] additionalContentTypes)
+            {
+                StatusCode = statusCode;
+                ContentType = contentType;
+                AdditionalContentTypes = additionalContentTypes ?? [];
+            }
+        }
+
+        """, Encoding.UTF8);
+
+    private static readonly SourceText ProducesProblemAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Specifies that the endpoint produces a problem details payload.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+        internal sealed class {{ProducesProblemAttributeName}} : global::System.Attribute
+        {
+            /// <summary>
+            /// Gets the HTTP status code returned by the endpoint.
+            /// </summary>
+            public int StatusCode { get; }
+
+            /// <summary>
+            /// Gets the primary content type produced by the endpoint.
+            /// </summary>
+            public string? ContentType { get; }
+
+            /// <summary>
+            /// Gets the additional content types produced by the endpoint.
+            /// </summary>
+            public string[] AdditionalContentTypes { get; }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="{{ProducesProblemAttributeName}}"/> class.
+            /// </summary>
+            /// <param name="statusCode">The HTTP status code returned by the endpoint.</param>
+            /// <param name="contentType">The primary content type produced by the endpoint.</param>
+            /// <param name="additionalContentTypes">Additional content types produced by the endpoint.</param>
+            public {{ProducesProblemAttributeName}}(int statusCode = global::Microsoft.AspNetCore.Http.StatusCodes.Status500InternalServerError, string? contentType = null, params string[] additionalContentTypes)
+            {
+                StatusCode = statusCode;
+                ContentType = contentType;
+                AdditionalContentTypes = additionalContentTypes ?? [];
+            }
+        }
+
+        """, Encoding.UTF8);
+
+    private static readonly SourceText ProducesValidationProblemAttributeSourceText = SourceText.From($$"""
+        {{FileHeader}}
+
+        namespace {{AttributesNamespace}};
+
+        /// <summary>
+        /// Specifies that the endpoint produces a validation problem details payload.
+        /// </summary>
+        [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+        internal sealed class {{ProducesValidationProblemAttributeName}} : global::System.Attribute
+        {
+            /// <summary>
+            /// Gets the HTTP status code returned by the endpoint.
+            /// </summary>
+            public int StatusCode { get; }
+
+            /// <summary>
+            /// Gets the primary content type produced by the endpoint.
+            /// </summary>
+            public string? ContentType { get; }
+
+            /// <summary>
+            /// Gets the additional content types produced by the endpoint.
+            /// </summary>
+            public string[] AdditionalContentTypes { get; }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="{{ProducesValidationProblemAttributeName}}"/> class.
+            /// </summary>
+            /// <param name="statusCode">The HTTP status code returned by the endpoint.</param>
+            /// <param name="contentType">The primary content type produced by the endpoint.</param>
+            /// <param name="additionalContentTypes">Additional content types produced by the endpoint.</param>
+            public {{ProducesValidationProblemAttributeName}}(int statusCode = global::Microsoft.AspNetCore.Http.StatusCodes.Status400BadRequest, string? contentType = null, params string[] additionalContentTypes)
+            {
+                StatusCode = statusCode;
+                ContentType = contentType;
+                AdditionalContentTypes = additionalContentTypes ?? [];
+            }
+        }
+
+        """, Encoding.UTF8);
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         context.RegisterPostInitializationOutput(RegisterAttributes);
@@ -177,7 +783,10 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
     private static HttpAttributeDefinition CreateHttpAttributeDefinition(string attributeName, string verb, bool allowEmptyPattern = false)
     {
         var fullyQualifiedName = $"{AttributesNamespace}.{attributeName}";
-        return new HttpAttributeDefinition(attributeName, fullyQualifiedName, $"{fullyQualifiedName}.gs.cs", verb, allowEmptyPattern);
+        var hint = $"{fullyQualifiedName}.gs.cs";
+        var summaryVerb = verb == FallbackHttpMethod ? "fallback" : verb;
+        var source = GenerateHttpAttributeSource(FileHeader, AttributesNamespace, attributeName, summaryVerb, allowEmptyPattern);
+        return new HttpAttributeDefinition(attributeName, fullyQualifiedName, hint, verb, allowEmptyPattern, SourceText.From(source, Encoding.UTF8));
     }
 
     private static IncrementalValueProvider<ImmutableArray<RequestHandler>> CombineRequestHandlers(
@@ -198,650 +807,25 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
     private static void RegisterAttributes(IncrementalGeneratorPostInitializationContext context)
     {
         foreach (var definition in HttpAttributeDefinitions)
-        {
-            var summaryVerb = definition.Verb == FallbackHttpMethod ? "fallback" : definition.Verb;
-            var source = GenerateHttpAttributeSource(FileHeader, AttributesNamespace, definition.Name, summaryVerb, definition.AllowEmptyPattern);
-            context.AddSource(definition.Hint, SourceText.From(source, Encoding.UTF8));
-        }
-
-        // RequireAuthorization
-        var requireAuthorizationSource = $$"""
-                                           {{FileHeader}}
-
-                                           namespace {{AttributesNamespace}};
-
-                                           /// <summary>
-                                           /// Specifies that authorization is required for the annotated endpoint or class.
-                                           /// Optionally restricts access to the specified authorization policies.
-                                           /// </summary>
-                                           [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-                                           internal sealed class {{RequireAuthorizationAttributeName}} : global::System.Attribute
-                                           {
-                                               /// <summary>
-                                               /// Gets the policy names that the endpoint or class requires.
-                                               /// </summary>
-                                               public string[] PolicyNames { get; }
-
-                                               /// <summary>
-                                               /// Marks the endpoint or class as requiring authorization.
-                                               /// </summary>
-                                               public {{RequireAuthorizationAttributeName}}()
-                                               {
-                                                   PolicyNames = [];
-                                               }
-
-                                               /// <summary>
-                                               /// Marks the endpoint or class as requiring authorization with one or more policies.
-                                               /// </summary>
-                                               public {{RequireAuthorizationAttributeName}}(params string[] policyNames)
-                                               {
-                                                   PolicyNames = policyNames ?? [];
-                                               }
-                                           }
-                                           """;
-        context.AddSource(RequireAuthorizationAttributeHint, SourceText.From(requireAuthorizationSource, Encoding.UTF8));
-
-        // RequireCors
-        var requireCorsSource = $$"""
-                                  {{FileHeader}}
-
-                                  namespace {{AttributesNamespace}};
-
-                                  /// <summary>
-                                  /// Specifies that the annotated endpoint requires a configured CORS policy.
-                                  /// </summary>
-                                  [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-                                  internal sealed class {{RequireCorsAttributeName}} : global::System.Attribute
-                                  {
-                                      /// <summary>
-                                      /// Gets the optional CORS policy name.
-                                      /// </summary>
-                                      public string? PolicyName { get; }
-
-                                      /// <summary>
-                                      /// Marks the endpoint or class as requiring the default CORS policy.
-                                      /// </summary>
-                                      public {{RequireCorsAttributeName}}()
-                                      {
-                                      }
-
-                                      /// <summary>
-                                      /// Marks the endpoint or class as requiring the specified named CORS policy.
-                                      /// </summary>
-                                      public {{RequireCorsAttributeName}}(string policyName)
-                                      {
-                                          PolicyName = policyName;
-                                      }
-                                  }
-                                  """;
-        context.AddSource(RequireCorsAttributeHint, SourceText.From(requireCorsSource, Encoding.UTF8));
-
-        // RequireRateLimiting
-        var requireRateLimitingSource = $$"""
-                                          {{FileHeader}}
-
-                                          namespace {{AttributesNamespace}};
-
-                                          /// <summary>
-                                          /// Specifies that the annotated endpoint requires the provided rate limiting policy.
-                                          /// </summary>
-                                          [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-                                          internal sealed class {{RequireRateLimitingAttributeName}} : global::System.Attribute
-                                          {
-                                              /// <summary>
-                                              /// Initializes a new instance of the <see cref="{{RequireRateLimitingAttributeName}}"/> class.
-                                              /// </summary>
-                                              /// <param name="policyName">The rate limiting policy to apply.</param>
-                                              public {{RequireRateLimitingAttributeName}}(string policyName)
-                                              {
-                                                  PolicyName = policyName;
-                                              }
-
-                                              /// <summary>
-                                              /// Gets the rate limiting policy name.
-                                              /// </summary>
-                                              public string PolicyName { get; }
-                                          }
-                                          """;
-        context.AddSource(RequireRateLimitingAttributeHint, SourceText.From(requireRateLimitingSource, Encoding.UTF8));
-
-        // RequireHost
-        var requireHostSource = $$"""
-                                  {{FileHeader}}
-
-                                  namespace {{AttributesNamespace}};
-
-                                  /// <summary>
-                                  /// Specifies the allowed hosts for the annotated endpoint or class.
-                                  /// </summary>
-                                  [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-                                  internal sealed class {{RequireHostAttributeName}} : global::System.Attribute
-                                  {
-                                      /// <summary>
-                                      /// Initializes a new instance of the <see cref="{{RequireHostAttributeName}}"/> class.
-                                      /// </summary>
-                                      /// <param name="hosts">The hosts that are allowed to access the endpoint.</param>
-                                      public {{RequireHostAttributeName}}(params string[] hosts)
-                                      {
-                                          Hosts = hosts ?? [];
-                                      }
-
-                                      /// <summary>
-                                      /// Gets the allowed hosts.
-                                      /// </summary>
-                                      public string[] Hosts { get; }
-                                  }
-                                  """;
-        context.AddSource(RequireHostAttributeHint, SourceText.From(requireHostSource, Encoding.UTF8));
-
-        // DisableAntiforgery
-        var disableAntiforgerySource = $$"""
-                                         {{FileHeader}}
-
-                                         namespace {{AttributesNamespace}};
-
-                                         /// <summary>
-                                         /// Disables antiforgery protection for the annotated endpoint or class.
-                                         /// </summary>
-                                         [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-                                         internal sealed class {{DisableAntiforgeryAttributeName}} : global::System.Attribute
-                                         {
-                                         }
-
-                                         """;
-        context.AddSource(DisableAntiforgeryAttributeHint, SourceText.From(disableAntiforgerySource, Encoding.UTF8));
-
-        // ShortCircuit
-        var shortCircuitSource = $$"""
-                                   {{FileHeader}}
-
-                                   namespace {{AttributesNamespace}};
-
-                                   /// <summary>
-                                   /// Marks the annotated endpoint or class to short-circuit the request pipeline.
-                                   /// </summary>
-                                   [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-                                   internal sealed class {{ShortCircuitAttributeName}} : global::System.Attribute
-                                   {
-                                   }
-
-                                   """;
-        context.AddSource(ShortCircuitAttributeHint, SourceText.From(shortCircuitSource, Encoding.UTF8));
-
-        // DisableRequestTimeout
-        var disableRequestTimeoutSource = $$"""
-                                            {{FileHeader}}
-
-                                            namespace {{AttributesNamespace}};
-
-                                            /// <summary>
-                                            /// Disables the request timeout for the annotated endpoint or class.
-                                            /// </summary>
-                                            [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-                                            internal sealed class {{DisableRequestTimeoutAttributeName}} : global::System.Attribute
-                                            {
-                                            }
-
-                                            """;
-        context.AddSource(DisableRequestTimeoutAttributeHint, SourceText.From(disableRequestTimeoutSource, Encoding.UTF8));
-
-        // DisableValidation
-        var disableValidationSource = $$"""
-                                       #if NET10_0_OR_GREATER
-                                       {{FileHeader}}
-
-                                       namespace {{AttributesNamespace}};
-
-                                       /// <summary>
-                                       /// Disables request validation for the annotated endpoint or class when targeting .NET 10 or later.
-                                       /// </summary>
-                                       [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-                                       internal sealed class {{DisableValidationAttributeName}} : global::System.Attribute
-                                       {
-                                       }
-                                       #endif
-
-                                       """;
-        context.AddSource(DisableValidationAttributeHint, SourceText.From(disableValidationSource, Encoding.UTF8));
-
-        // RequestTimeout
-        var requestTimeoutSource = $$"""
-                                         {{FileHeader}}
-
-                                         namespace {{AttributesNamespace}};
-
-                                          /// <summary>
-                                          /// Applies the request timeout metadata to the annotated endpoint or class.
-                                          /// </summary>
-                                          [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-                                          internal sealed class {{RequestTimeoutAttributeName}} : global::System.Attribute
-                                          {
-                                              /// <summary>
-                                              /// Gets the optional request timeout policy name.
-                                              /// </summary>
-                                              public string? PolicyName { get; init; }
-
-                                              /// <summary>
-                                              /// Applies the default request timeout behavior.
-                                              /// </summary>
-                                              public {{RequestTimeoutAttributeName}}()
-                                              {
-                                              }
-
-                                              /// <summary>
-                                              /// Applies the specified request timeout policy.
-                                              /// </summary>
-                                              /// <param name="policyName">The request timeout policy name.</param>
-                                              public {{RequestTimeoutAttributeName}}(string policyName)
-                                              {
-                                                  PolicyName = policyName;
-                                         }
-                                     }
-
-                                     """;
-        context.AddSource(RequestTimeoutAttributeHint, SourceText.From(requestTimeoutSource, Encoding.UTF8));
-
-        // Order
-        var orderSource = $$"""
-                            {{FileHeader}}
-
-                            namespace {{AttributesNamespace}};
-
-                            /// <summary>
-                            /// Specifies the order for the annotated endpoint when building conventions.
-                            /// </summary>
-                            [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-                            internal sealed class {{OrderAttributeName}} : global::System.Attribute
-                            {
-                                /// <summary>
-                                /// Gets the order that will be applied to the endpoint.
-                                /// </summary>
-                                public int Order { get; }
-
-                                /// <summary>
-                                /// Initializes a new instance of the <see cref="{{OrderAttributeName}}"/> class.
-                                /// </summary>
-                                /// <param name="order">The order value to apply to the endpoint.</param>
-                                public {{OrderAttributeName}}(int order)
-                                {
-                                    Order = order;
-                                }
-                            }
-
-                            """;
-        context.AddSource(OrderAttributeHint, SourceText.From(orderSource, Encoding.UTF8));
-
-        // MapGroup
-        var mapGroupSource = $$"""
-                               {{FileHeader}}
-
-                               namespace {{AttributesNamespace}};
-
-                               /// <summary>
-                               /// Specifies the route group for the annotated class.
-                               /// </summary>
-                               [global::System.AttributeUsage(global::System.AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
-                               internal sealed class {{MapGroupAttributeName}} : global::System.Attribute
-                               {
-                                   /// <summary>
-                                   /// Gets the route group pattern.
-                                   /// </summary>
-                                   public string Pattern { get; }
-
-                                   /// <summary>
-                                   /// Gets or sets the endpoint group name.
-                                   /// </summary>
-                                   public string? Name { get; init; }
-
-                                   /// <summary>
-                                   /// Initializes a new instance of the <see cref="{{MapGroupAttributeName}}"/> class.
-                                   /// </summary>
-                                   /// <param name="pattern">The route group pattern to apply.</param>
-                                   public {{MapGroupAttributeName}}(string pattern)
-                                   {
-                                       Pattern = pattern;
-                                   }
-                               }
-
-                               """;
-        context.AddSource(MapGroupAttributeHint, SourceText.From(mapGroupSource, Encoding.UTF8));
-
-        // Summary
-        var summarySource = $$"""
-                              {{FileHeader}}
-
-                              namespace {{AttributesNamespace}};
-
-                              /// <summary>
-                              /// Specifies the summary metadata for the annotated endpoint.
-                              /// </summary>
-                              [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-                              internal sealed class {{SummaryAttributeName}} : global::System.Attribute
-                              {
-                                  /// <summary>
-                                  /// Gets the summary value for the endpoint.
-                                  /// </summary>
-                                  public string Summary { get; }
-
-                                  /// <summary>
-                                  /// Initializes a new instance of the <see cref="{{SummaryAttributeName}}"/> class.
-                                  /// </summary>
-                                  /// <param name="summary">The summary to apply to the endpoint.</param>
-                                  public {{SummaryAttributeName}}(string summary)
-                                  {
-                                      Summary = summary;
-                                  }
-                              }
-
-                              """;
-        context.AddSource(SummaryAttributeHint, SourceText.From(summarySource, Encoding.UTF8));
-
-        // Accepts
-        var acceptsSource = $$"""
-                               {{FileHeader}}
-
-                              namespace {{AttributesNamespace}};
-
-                              /// <summary>
-                              /// Specifies the request type and content types accepted by the annotated endpoint or class.
-                              /// </summary>
-                              [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
-                              internal sealed class {{AcceptsAttributeName}} : global::System.Attribute
-                              {
-                                  /// <summary>
-                                  /// Gets the request type accepted by the endpoint.
-                                  /// </summary>
-                                  public global::System.Type? RequestType { get; init; }
-
-                                  /// <summary>
-                                  /// Gets a value indicating whether the request body is optional.
-                                  /// </summary>
-                                  public bool IsOptional { get; init; }
-
-                                  /// <summary>
-                                  /// Gets the primary content type accepted by the endpoint.
-                                  /// </summary>
-                                  public string ContentType { get; }
-
-                                  /// <summary>
-                                  /// Gets the additional content types accepted by the endpoint.
-                                  /// </summary>
-                                  public string[] AdditionalContentTypes { get; }
-
-                                  /// <summary>
-                                  /// Initializes a new instance of the <see cref="{{AcceptsAttributeName}}"/> class.
-                                  /// </summary>
-                                  /// <param name="contentType">The primary content type accepted by the endpoint.</param>
-                                  /// <param name="additionalContentTypes">Additional content types accepted by the endpoint.</param>
-                                  public {{AcceptsAttributeName}}(string contentType = "application/json", params string[] additionalContentTypes)
-                                  {
-                                      ContentType = string.IsNullOrWhiteSpace(contentType) ? "application/json" : contentType;
-                                      AdditionalContentTypes = additionalContentTypes ?? [];
-                                  }
-                              }
-
-                              /// <summary>
-                              /// Specifies the request type using a generic argument and the content types accepted by the annotated endpoint or class.
-                              /// </summary>
-                              /// <typeparam name="TRequest">The CLR type of the request body.</typeparam>
-                              [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
-                              internal sealed class {{AcceptsAttributeName}}<TRequest> : global::System.Attribute
-                              {
-                                  /// <summary>
-                                  /// Gets the request type accepted by the endpoint.
-                                  /// </summary>
-                                  public global::System.Type RequestType => typeof(TRequest);
-
-                                  /// <summary>
-                                  /// Gets a value indicating whether the request body is optional.
-                                  /// </summary>
-                                  public bool IsOptional { get; init; }
-
-                                  /// <summary>
-                                  /// Gets the primary content type accepted by the endpoint.
-                                  /// </summary>
-                                  public string ContentType { get; }
-
-                                  /// <summary>
-                                  /// Gets the additional content types accepted by the endpoint.
-                                  /// </summary>
-                                  public string[] AdditionalContentTypes { get; }
-
-                                  /// <summary>
-                                  /// Initializes a new instance of the generic Accepts attribute class.
-                                  /// </summary>
-                                  /// <param name="contentType">The primary content type accepted by the endpoint.</param>
-                                  /// <param name="additionalContentTypes">Additional content types accepted by the endpoint.</param>
-                                  public {{AcceptsAttributeName}}(string contentType = "application/json", params string[] additionalContentTypes)
-                                  {
-                                      ContentType = string.IsNullOrWhiteSpace(contentType) ? "application/json" : contentType;
-                                      AdditionalContentTypes = additionalContentTypes ?? [];
-                                  }
-                              }
-
-                              """;
-        context.AddSource(AcceptsAttributeHint, SourceText.From(acceptsSource, Encoding.UTF8));
-
-        // EndpointFilter
-        var endpointFilterSource = $$"""
-                                     {{FileHeader}}
-
-                                     namespace {{AttributesNamespace}};
-
-                                     /// <summary>
-                                     /// Specifies an endpoint filter type to apply to the annotated endpoint or class.
-                                     /// </summary>
-                                     [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
-                                     internal sealed class {{EndpointFilterAttributeName}} : global::System.Attribute
-                                     {
-                                         /// <summary>
-                                         /// Gets the CLR type of the endpoint filter.
-                                         /// </summary>
-                                         public global::System.Type FilterType { get; }
-
-                                         /// <summary>
-                                         /// Initializes a new instance of the <see cref="{{EndpointFilterAttributeName}}"/> class.
-                                         /// </summary>
-                                         /// <param name="filterType">The CLR type of the endpoint filter.</param>
-                                         public {{EndpointFilterAttributeName}}(global::System.Type filterType)
-                                         {
-                                             FilterType = filterType ?? throw new global::System.ArgumentNullException(nameof(filterType));
-                                         }
-                                     }
-
-                                     /// <summary>
-                                     /// Specifies an endpoint filter type using a generic argument.
-                                     /// </summary>
-                                     /// <typeparam name="TFilter">The CLR type of the endpoint filter.</typeparam>
-                                     [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
-                                     internal sealed class {{EndpointFilterAttributeName}}<TFilter> : global::System.Attribute
-                                     {
-                                         /// <summary>
-                                         /// Gets the CLR type of the endpoint filter.
-                                         /// </summary>
-                                         public global::System.Type FilterType => typeof(TFilter);
-                                     }
-
-                                     """;
-        context.AddSource(EndpointFilterAttributeHint, SourceText.From(endpointFilterSource, Encoding.UTF8));
-
-        // Produces
-        var producesSource = $$"""
-                               {{FileHeader}}
-
-                               namespace {{AttributesNamespace}};
-
-                               /// <summary>
-                               /// Specifies a response type, status code, and content types produced by the annotated endpoint or class.
-                               /// </summary>
-                               [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
-                               internal sealed class {{ProducesResponseAttributeName}} : global::System.Attribute
-                               {
-                               /// <summary>
-                               /// Gets the response type produced by the endpoint.
-                               /// </summary>
-                               public global::System.Type? ResponseType { get; init; }
-
-                                   /// <summary>
-                                   /// Gets the HTTP status code returned by the endpoint.
-                                   /// </summary>
-                                   public int StatusCode { get; }
-
-                                   /// <summary>
-                                   /// Gets the primary content type produced by the endpoint.
-                                   /// </summary>
-                                   public string? ContentType { get; }
-
-                                   /// <summary>
-                                   /// Gets the additional content types produced by the endpoint.
-                                   /// </summary>
-                                   public string[] AdditionalContentTypes { get; }
-
-                                   /// <summary>
-                                   /// Initializes a new instance of the <see cref="{{ProducesResponseAttributeName}}"/> class.
-                                   /// </summary>
-                                   /// <param name="statusCode">The HTTP status code returned by the endpoint.</param>
-                                   /// <param name="contentType">The primary content type produced by the endpoint.</param>
-                                   /// <param name="additionalContentTypes">Additional content types produced by the endpoint.</param>
-                                   public {{ProducesResponseAttributeName}}(int statusCode = global::Microsoft.AspNetCore.Http.StatusCodes.Status200OK, string? contentType = null, params string[] additionalContentTypes)
-                                   {
-                                       StatusCode = statusCode;
-                                       ContentType = contentType;
-                                       AdditionalContentTypes = additionalContentTypes ?? [];
-                                   }
-                               }
-
-                               /// <summary>
-                               /// Specifies a response type using a generic argument along with status code and content types produced by the annotated endpoint or class.
-                               /// </summary>
-                               /// <typeparam name="TResponse">The CLR type of the response body.</typeparam>
-                               [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
-                               internal sealed class {{ProducesResponseAttributeName}}<TResponse> : global::System.Attribute
-                               {
-                                   /// <summary>
-                                   /// Gets the response type produced by the endpoint.
-                                   /// </summary>
-                                   public global::System.Type ResponseType => typeof(TResponse);
-
-                                   /// <summary>
-                                   /// Gets the HTTP status code returned by the endpoint.
-                                   /// </summary>
-                                   public int StatusCode { get; }
-
-                                   /// <summary>
-                                   /// Gets the primary content type produced by the endpoint.
-                                   /// </summary>
-                                   public string? ContentType { get; }
-
-                                   /// <summary>
-                                   /// Gets the additional content types produced by the endpoint.
-                                   /// </summary>
-                                   public string[] AdditionalContentTypes { get; }
-
-                                   /// <summary>
-                                   /// Initializes a new instance of the generic Produces attribute class.
-                                   /// </summary>
-                                   /// <param name="statusCode">The HTTP status code returned by the endpoint.</param>
-                                   /// <param name="contentType">The primary content type produced by the endpoint.</param>
-                                   /// <param name="additionalContentTypes">Additional content types produced by the endpoint.</param>
-                                   public {{ProducesResponseAttributeName}}(int statusCode = global::Microsoft.AspNetCore.Http.StatusCodes.Status200OK, string? contentType = null, params string[] additionalContentTypes)
-                                   {
-                                       StatusCode = statusCode;
-                                       ContentType = contentType;
-                                       AdditionalContentTypes = additionalContentTypes ?? [];
-                                   }
-                               }
-
-                               """;
-        context.AddSource(ProducesResponseAttributeHint, SourceText.From(producesSource, Encoding.UTF8));
-
-        // ProducesProblem
-        var producesProblemSource = $$"""
-                                      {{FileHeader}}
-
-                                      namespace {{AttributesNamespace}};
-
-                                      /// <summary>
-                                      /// Specifies that the endpoint produces a problem details payload.
-                                      /// </summary>
-                                      [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
-                                      internal sealed class {{ProducesProblemAttributeName}} : global::System.Attribute
-                                      {
-                                          /// <summary>
-                                          /// Gets the HTTP status code returned by the endpoint.
-                                          /// </summary>
-                                          public int StatusCode { get; }
-
-                                          /// <summary>
-                                          /// Gets the primary content type produced by the endpoint.
-                                          /// </summary>
-                                          public string? ContentType { get; }
-
-                                          /// <summary>
-                                          /// Gets the additional content types produced by the endpoint.
-                                          /// </summary>
-                                          public string[] AdditionalContentTypes { get; }
-
-                                          /// <summary>
-                                          /// Initializes a new instance of the <see cref="{{ProducesProblemAttributeName}}"/> class.
-                                          /// </summary>
-                                          /// <param name="statusCode">The HTTP status code returned by the endpoint.</param>
-                                          /// <param name="contentType">The primary content type produced by the endpoint.</param>
-                                          /// <param name="additionalContentTypes">Additional content types produced by the endpoint.</param>
-                                          public {{ProducesProblemAttributeName}}(int statusCode = global::Microsoft.AspNetCore.Http.StatusCodes.Status500InternalServerError, string? contentType = null, params string[] additionalContentTypes)
-                                          {
-                                              StatusCode = statusCode;
-                                              ContentType = contentType;
-                                              AdditionalContentTypes = additionalContentTypes ?? [];
-                                          }
-                                      }
-
-                                      """;
-        context.AddSource(ProducesProblemAttributeHint, SourceText.From(producesProblemSource, Encoding.UTF8));
-
-        // ProducesValidationProblem
-        var producesValidationProblemSource = $$"""
-                                                {{FileHeader}}
-
-                                                namespace {{AttributesNamespace}};
-
-                                                /// <summary>
-                                                /// Specifies that the endpoint produces a validation problem details payload.
-                                                /// </summary>
-                                                [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
-                                                internal sealed class {{ProducesValidationProblemAttributeName}} : global::System.Attribute
-                                                {
-                                                    /// <summary>
-                                                    /// Gets the HTTP status code returned by the endpoint.
-                                                    /// </summary>
-                                                    public int StatusCode { get; }
-
-                                                    /// <summary>
-                                                    /// Gets the primary content type produced by the endpoint.
-                                                    /// </summary>
-                                                    public string? ContentType { get; }
-
-                                                    /// <summary>
-                                                    /// Gets the additional content types produced by the endpoint.
-                                                    /// </summary>
-                                                    public string[] AdditionalContentTypes { get; }
-
-                                                    /// <summary>
-                                                    /// Initializes a new instance of the <see cref="{{ProducesValidationProblemAttributeName}}"/> class.
-                                                    /// </summary>
-                                                    /// <param name="statusCode">The HTTP status code returned by the endpoint.</param>
-                                                    /// <param name="contentType">The primary content type produced by the endpoint.</param>
-                                                    /// <param name="additionalContentTypes">Additional content types produced by the endpoint.</param>
-                                                    public {{ProducesValidationProblemAttributeName}}(int statusCode = global::Microsoft.AspNetCore.Http.StatusCodes.Status400BadRequest, string? contentType = null, params string[] additionalContentTypes)
-                                                    {
-                                                        StatusCode = statusCode;
-                                                        ContentType = contentType;
-                                                        AdditionalContentTypes = additionalContentTypes ?? [];
-                                                    }
-                                                }
-
-                                                """;
-        context.AddSource(ProducesValidationProblemAttributeHint, SourceText.From(producesValidationProblemSource, Encoding.UTF8));
+            context.AddSource(definition.Hint, definition.SourceText);
+
+        context.AddSource(RequireAuthorizationAttributeHint, RequireAuthorizationAttributeSourceText);
+        context.AddSource(RequireCorsAttributeHint, RequireCorsAttributeSourceText);
+        context.AddSource(RequireRateLimitingAttributeHint, RequireRateLimitingAttributeSourceText);
+        context.AddSource(RequireHostAttributeHint, RequireHostAttributeSourceText);
+        context.AddSource(DisableAntiforgeryAttributeHint, DisableAntiforgeryAttributeSourceText);
+        context.AddSource(ShortCircuitAttributeHint, ShortCircuitAttributeSourceText);
+        context.AddSource(DisableRequestTimeoutAttributeHint, DisableRequestTimeoutAttributeSourceText);
+        context.AddSource(DisableValidationAttributeHint, DisableValidationAttributeSourceText);
+        context.AddSource(RequestTimeoutAttributeHint, RequestTimeoutAttributeSourceText);
+        context.AddSource(OrderAttributeHint, OrderAttributeSourceText);
+        context.AddSource(MapGroupAttributeHint, MapGroupAttributeSourceText);
+        context.AddSource(SummaryAttributeHint, SummaryAttributeSourceText);
+        context.AddSource(AcceptsAttributeHint, AcceptsAttributeSourceText);
+        context.AddSource(EndpointFilterAttributeHint, EndpointFilterAttributeSourceText);
+        context.AddSource(ProducesResponseAttributeHint, ProducesResponseAttributeSourceText);
+        context.AddSource(ProducesProblemAttributeHint, ProducesProblemAttributeSourceText);
+        context.AddSource(ProducesValidationProblemAttributeHint, ProducesValidationProblemAttributeSourceText);
     }
 
     private static string GenerateHttpAttributeSource(
@@ -1275,7 +1259,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         if (className.StartsWith(GlobalPrefix, StringComparison.Ordinal))
             className = className.Substring(GlobalPrefix.Length);
 
-        var builder = new StringBuilder(className.Length + 8);
+        var builder = StringBuilderPool.Get(className.Length + 8);
         builder.Append('_');
 
         foreach (var character in className)
@@ -1284,7 +1268,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         }
 
         builder.Append("_Group");
-        return builder.ToString();
+        return StringBuilderPool.ToStringAndReturn(builder);
     }
 
     private static EquatableImmutableArray<string>? GetStringArrayValues(TypedConstant typedConstant)
@@ -1935,7 +1919,8 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                           """
         );
 
-        context.AddSource(AddEndpointHandlersMethodHint, SourceText.From(source.ToString(), Encoding.UTF8));
+        var sourceText = StringBuilderPool.ToStringAndReturn(source);
+        context.AddSource(AddEndpointHandlersMethodHint, SourceText.From(sourceText, Encoding.UTF8));
     }
 
     [SuppressMessage("Major Code Smell", "S3267:Loops should be simplified by calling the \"Select\" LINQ method", Justification = "Manual loops avoid repeated allocations in the source generator.")]
@@ -1975,7 +1960,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             _ => estimate,
         };
 
-        return new StringBuilder(estimate);
+        return StringBuilderPool.Get(estimate);
     }
 
     private static void GenerateUseEndpointHandlersClass(SourceProductionContext context, ImmutableArray<RequestHandler> requestHandlers)
@@ -2045,7 +2030,8 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                           """
         );
 
-        context.AddSource(UseEndpointHandlersMethodHint, SourceText.From(source.ToString(), Encoding.UTF8));
+        var sourceText = StringBuilderPool.ToStringAndReturn(source);
+        context.AddSource(UseEndpointHandlersMethodHint, SourceText.From(sourceText, Encoding.UTF8));
     }
 
     [SuppressMessage("Major Code Smell", "S3267:Loops should be simplified by calling the \"Select\" LINQ method", Justification = "Manual loops avoid repeated allocations in the source generator.")]
@@ -2543,7 +2529,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         if (estimate > 65536)
             estimate = 65536;
 
-        return new StringBuilder(estimate);
+        return StringBuilderPool.Get(estimate);
     }
 
     [SuppressMessage("Globalization", "CA1308: Normalize strings to uppercase", Justification = "C# boolean literals must be lowercase.")]
@@ -2610,7 +2596,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         if (value is null)
             return "null";
 
-        var sb = new StringBuilder(value.Length + 2);
+        var sb = StringBuilderPool.Get(value.Length + 2);
         sb.Append('"');
         foreach (var c in value)
         {
@@ -2644,7 +2630,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             }
         }
         sb.Append('"');
-        return sb.ToString();
+        return StringBuilderPool.ToStringAndReturn(sb);
     }
 
     private static void AppendAdditionalContentTypes(StringBuilder source, EquatableImmutableArray<string>? additionalContentTypes)
@@ -2697,7 +2683,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         };
     }
 
-    private readonly record struct HttpAttributeDefinition(string Name, string FullyQualifiedName, string Hint, string Verb, bool AllowEmptyPattern);
+    private readonly record struct HttpAttributeDefinition(string Name, string FullyQualifiedName, string Hint, string Verb, bool AllowEmptyPattern, SourceText SourceText);
 
     private readonly record struct RequestHandler(
         RequestHandlerClass Class,


### PR DESCRIPTION
## Summary
- precompute and cache all generated attribute source texts so post initialization no longer rebuilds strings
- add a reusable StringBuilder pool and use it throughout the generator for large source files, map group identifiers, and string literal emission

## Testing
- `dotnet test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919592332788328a5870fc78ac718f0)