### PR TITLE
Add cancellation checks to source generation context

### DIFF
--- a/src/GeneratedEndpoints/MinimalApiGenerator.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.cs
@@ -1030,6 +1030,8 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
 
     private static void GenerateSource(SourceProductionContext context, ImmutableArray<RequestHandler> requestHandlers)
     {
+        context.CancellationToken.ThrowIfCancellationRequested();
+
         var sorted = SortRequestHandlers(requestHandlers);
         sorted = EnsureUniqueEndpointNames(sorted);
 
@@ -1146,6 +1148,8 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
 
     private static void GenerateAddEndpointHandlersClass(SourceProductionContext context, ImmutableArray<RequestHandler> requestHandlers)
     {
+        context.CancellationToken.ThrowIfCancellationRequested();
+
         var nonStaticClassNames = GetDistinctNonStaticClassNames(requestHandlers);
         var source = GetAddEndpointHandlersStringBuilder(nonStaticClassNames);
         source.AppendLine(FileHeader);
@@ -1234,6 +1238,8 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
 
     private static void GenerateUseEndpointHandlersClass(SourceProductionContext context, ImmutableArray<RequestHandler> requestHandlers)
     {
+        context.CancellationToken.ThrowIfCancellationRequested();
+
         var source = GetUseEndpointHandlersStringBuilder(requestHandlers);
         source.AppendLine(FileHeader);
 


### PR DESCRIPTION
## Summary
- ensure the three `SourceProductionContext` entry points check `context.CancellationToken`

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69196a10b3e08328b548f0e2262c94a5)