### PR TITLE
Add diagnostics for misconfigured endpoint definitions

### DIFF
--- a/src/GeneratedEndpoints/MinimalApiGenerator.Diagnostics.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.Diagnostics.cs
@@ -1,0 +1,48 @@
+using Microsoft.CodeAnalysis;
+
+namespace GeneratedEndpoints;
+
+public sealed partial class MinimalApiGenerator
+{
+    private const string DiagnosticCategory = "GeneratedEndpoints";
+
+    private static readonly DiagnosticDescriptor InvalidEndpointTargetDiagnostic = new(
+        "GE0001",
+        title: "Map attribute must target a method",
+        messageFormat: "The '{0}' attribute can only be applied to methods.",
+        category: DiagnosticCategory,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor InvalidEndpointContainerDiagnostic = new(
+        "GE0002",
+        title: "Endpoint methods must be declared inside a class",
+        messageFormat: "The endpoint method '{0}' must be declared inside a class.",
+        category: DiagnosticCategory,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor ConflictingAuthorizationAttributesDiagnostic = new(
+        "GE0003",
+        title: "Conflicting authorization attributes",
+        messageFormat: "The endpoint '{0}' cannot combine [RequireAuthorization] and [AllowAnonymous].",
+        category: DiagnosticCategory,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor DuplicateEndpointNameDiagnostic = new(
+        "GE0004",
+        title: "Duplicate endpoint name",
+        messageFormat: "The endpoint name '{0}' is used by multiple handlers for method '{1}'. Endpoint names must be unique.",
+        category: DiagnosticCategory,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor InvalidBindingAnnotationDiagnostic = new(
+        "GE0005",
+        title: "Invalid binding annotation",
+        messageFormat: "The binding name specified for parameter '{0}' must be a non-empty string.",
+        category: DiagnosticCategory,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+}

--- a/src/GeneratedEndpoints/MinimalApiGenerator.Types.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.Types.cs
@@ -1,4 +1,5 @@
 using GeneratedEndpoints.Common;
+using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
@@ -19,7 +20,8 @@ public sealed partial class MinimalApiGenerator
         RequestHandlerMethod Method,
         string HttpMethod,
         string Pattern,
-        EndpointConfiguration Configuration
+        EndpointConfiguration Configuration,
+        Location? Location
     );
 
     private readonly record struct RequestHandlerClass(
@@ -92,6 +94,8 @@ public sealed partial class MinimalApiGenerator
 
     private readonly record struct Parameter(string Name, string Type, string BindingPrefix);
 
+    private readonly record struct BindingNameResult(string? Name, bool HasValue, bool IsInvalid, Location? Location);
+
     private readonly record struct ConfigureMethodDetails(bool HasConfigureMethod, bool ConfigureMethodAcceptsServiceProvider);
 
     private struct EndpointAttributeState
@@ -115,6 +119,8 @@ public sealed partial class MinimalApiGenerator
         public HashSet<string>? EndpointFilterSet;
         public bool HasAllowAnonymousAttribute;
         public bool HasRequireAuthorizationAttribute;
+        public Location? AllowAnonymousLocation;
+        public Location? RequireAuthorizationLocation;
         public bool? ShortCircuit;
         public bool? DisableValidation;
         public bool? DisableRequestTimeout;
@@ -196,7 +202,11 @@ public sealed partial class MinimalApiGenerator
         private RequestHandlerClass _value;
         private bool _initialized;
 
-        public RequestHandlerClass GetOrCreate(INamedTypeSymbol classSymbol, CompilationTypeCache compilationCache, CancellationToken cancellationToken)
+        public RequestHandlerClass GetOrCreate(
+            INamedTypeSymbol classSymbol,
+            CompilationTypeCache compilationCache,
+            Action<Diagnostic>? reportDiagnostic,
+            CancellationToken cancellationToken)
         {
             if (_initialized)
                 return _value;
@@ -216,7 +226,15 @@ public sealed partial class MinimalApiGenerator
 
                 var mapGroupPattern = GetMapGroupPattern(classSymbol);
                 var mapGroupIdentifier = mapGroupPattern is null ? null : GetMapGroupIdentifier(name);
-                var classConfiguration = GetEndpointConfiguration(classSymbol.GetAttributes(), null, null, null, false);
+                var classConfiguration = GetEndpointConfiguration(
+                    classSymbol,
+                    classSymbol.GetAttributes(),
+                    null,
+                    null,
+                    null,
+                    false,
+                    reportDiagnostic,
+                    cancellationToken);
 
                 _value = new RequestHandlerClass(name, isStatic, configureMethodDetails.HasConfigureMethod,
                     configureMethodDetails.ConfigureMethodAcceptsServiceProvider, mapGroupPattern, mapGroupIdentifier, classConfiguration

--- a/src/GeneratedEndpoints/MinimalApiGenerator.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Buffers;
+﻿using System;
+using System.Buffers;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -131,15 +132,28 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (context.TargetSymbol is not IMethodSymbol requestHandlerMethodSymbol)
-            return null;
         var attribute = context.Attributes[0];
+        var attributeLocation = GetAttributeLocation(attribute, cancellationToken) ?? context.TargetNode.GetLocation();
 
-        var requestHandlerClass = GetRequestHandlerClass(requestHandlerMethodSymbol, context.SemanticModel.Compilation, cancellationToken);
-        if (requestHandlerClass is null)
+        if (context.TargetSymbol is not IMethodSymbol requestHandlerMethodSymbol)
+        {
+            ReportDiagnostic(context.ReportDiagnostic, InvalidEndpointTargetDiagnostic, attributeLocation, attribute.AttributeClass?.Name ?? "Map");
             return null;
+        }
 
-        var requestHandlerMethod = GetRequestHandlerMethod(requestHandlerMethodSymbol, cancellationToken);
+        if (requestHandlerMethodSymbol.ContainingType is not { TypeKind: TypeKind.Class })
+        {
+            ReportDiagnostic(context.ReportDiagnostic, InvalidEndpointContainerDiagnostic, attributeLocation, requestHandlerMethodSymbol.Name);
+            return null;
+        }
+
+        var requestHandlerClass = GetRequestHandlerClass(
+            requestHandlerMethodSymbol,
+            context.SemanticModel.Compilation,
+            context.ReportDiagnostic,
+            cancellationToken);
+
+        var requestHandlerMethod = GetRequestHandlerMethod(requestHandlerMethodSymbol, context.ReportDiagnostic, cancellationToken);
 
         var (httpMethod, pattern, name) = GetRequestHandlerAttribute(attribute, cancellationToken);
 
@@ -147,9 +161,17 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
 
         name ??= RemoveAsyncSuffix(requestHandlerMethod.Name);
 
-        var methodConfiguration = GetEndpointConfiguration(requestHandlerMethodSymbol.GetAttributes(), name, displayName, description, true);
+        var methodConfiguration = GetEndpointConfiguration(
+            requestHandlerMethodSymbol,
+            requestHandlerMethodSymbol.GetAttributes(),
+            name,
+            displayName,
+            description,
+            true,
+            context.ReportDiagnostic,
+            cancellationToken);
 
-        var requestHandler = new RequestHandler(requestHandlerClass.Value, requestHandlerMethod, httpMethod, pattern, methodConfiguration);
+        var requestHandler = new RequestHandler(requestHandlerClass.Value, requestHandlerMethod, httpMethod, pattern, methodConfiguration, attributeLocation);
 
         return requestHandler;
     }
@@ -215,16 +237,25 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
     }
 
     private static EndpointConfiguration GetEndpointConfiguration(
+        ISymbol ownerSymbol,
         ImmutableArray<AttributeData> attributes,
         string? name,
         string? displayName,
         string? description,
-        bool enforceMethodRequireAuthorizationRules
+        bool enforceMethodRequireAuthorizationRules,
+        Action<Diagnostic>? reportDiagnostic,
+        CancellationToken cancellationToken
     )
     {
         var state = new EndpointAttributeState();
 
-        GetAdditionalRequestHandlerAttributeValues(attributes, ref state);
+        GetAdditionalRequestHandlerAttributeValues(attributes, ref state, cancellationToken);
+
+        if (state.HasAllowAnonymousAttribute && state.HasRequireAuthorizationAttribute)
+        {
+            var conflictLocation = state.AllowAnonymousLocation ?? state.RequireAuthorizationLocation ?? (ownerSymbol.Locations.Length > 0 ? ownerSymbol.Locations[0] : null);
+            ReportDiagnostic(reportDiagnostic, ConflictingAuthorizationAttributesDiagnostic, conflictLocation, ownerSymbol.Name);
+        }
 
         if (enforceMethodRequireAuthorizationRules && state is { HasRequireAuthorizationAttribute: true, HasAllowAnonymousAttribute: false })
             state.AllowAnonymous = false;
@@ -244,7 +275,10 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
         );
     }
 
-    private static void GetAdditionalRequestHandlerAttributeValues(ImmutableArray<AttributeData> attributes, ref EndpointAttributeState state)
+    private static void GetAdditionalRequestHandlerAttributeValues(
+        ImmutableArray<AttributeData> attributes,
+        ref EndpointAttributeState state,
+        CancellationToken cancellationToken)
     {
         ref var tags = ref state.Tags;
         ref var requireAuthorization = ref state.RequireAuthorization;
@@ -265,6 +299,8 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
         ref var endpointFilterSet = ref state.EndpointFilterSet;
         ref var hasAllowAnonymousAttribute = ref state.HasAllowAnonymousAttribute;
         ref var hasRequireAuthorizationAttribute = ref state.HasRequireAuthorizationAttribute;
+        ref var allowAnonymousLocation = ref state.AllowAnonymousLocation;
+        ref var requireAuthorizationLocation = ref state.RequireAuthorizationLocation;
         ref var shortCircuit = ref state.ShortCircuit;
         ref var disableValidation = ref state.DisableValidation;
         ref var disableRequestTimeout = ref state.DisableRequestTimeout;
@@ -276,6 +312,8 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
 
         foreach (var attribute in attributes)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var attributeClass = attribute.AttributeClass;
             if (attributeClass is null)
                 continue;
@@ -334,6 +372,7 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
                 case GeneratedAttributeKind.RequireAuthorization:
                     requireAuthorization = true;
                     hasRequireAuthorizationAttribute = true;
+                    requireAuthorizationLocation ??= GetAttributeLocation(attribute, cancellationToken);
                     if (attribute.ConstructorArguments.Length == 1)
                     {
                         var arg = attribute.ConstructorArguments[0];
@@ -413,6 +452,7 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
             {
                 allowAnonymous = true;
                 hasAllowAnonymousAttribute = true;
+                allowAnonymousLocation ??= GetAttributeLocation(attribute, cancellationToken);
                 continue;
             }
 
@@ -778,21 +818,28 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
         return list?.ToEquatableImmutableArray() ?? EquatableImmutableArray<string>.Empty;
     }
 
-    private static RequestHandlerMethod GetRequestHandlerMethod(IMethodSymbol methodSymbol, CancellationToken cancellationToken)
+    private static RequestHandlerMethod GetRequestHandlerMethod(
+        IMethodSymbol methodSymbol,
+        Action<Diagnostic>? reportDiagnostic,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         var name = methodSymbol.Name;
         var isStatic = methodSymbol.IsStatic;
         var isAwaitable = methodSymbol.ReturnType.IsTask(out _) || methodSymbol.ReturnType.IsValueTask(out _);
-        var parameters = GetRequestHandlerParameters(methodSymbol, cancellationToken);
+        var parameters = GetRequestHandlerParameters(methodSymbol, reportDiagnostic, cancellationToken);
 
         var requestHandlerMethod = new RequestHandlerMethod(name, isStatic, isAwaitable, parameters);
 
         return requestHandlerMethod;
     }
 
-    private static RequestHandlerClass? GetRequestHandlerClass(IMethodSymbol methodSymbol, Compilation compilation, CancellationToken cancellationToken)
+    private static RequestHandlerClass? GetRequestHandlerClass(
+        IMethodSymbol methodSymbol,
+        Compilation compilation,
+        Action<Diagnostic>? reportDiagnostic,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -802,7 +849,7 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
 
         var typeCache = GetCompilationTypeCache(compilation);
         var cacheEntry = RequestHandlerClassCache.GetValue(classSymbol, static _ => new RequestHandlerClassCacheEntry());
-        var requestHandlerClass = cacheEntry.GetOrCreate(classSymbol, typeCache, cancellationToken);
+        var requestHandlerClass = cacheEntry.GetOrCreate(classSymbol, typeCache, reportDiagnostic, cancellationToken);
         return requestHandlerClass;
     }
 
@@ -953,7 +1000,10 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
         return string.Equals(containingNamespace, "System", StringComparison.Ordinal);
     }
 
-    private static EquatableImmutableArray<Parameter> GetRequestHandlerParameters(IMethodSymbol methodSymbol, CancellationToken cancellationToken)
+    private static EquatableImmutableArray<Parameter> GetRequestHandlerParameters(
+        IMethodSymbol methodSymbol,
+        Action<Diagnostic>? reportDiagnostic,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -965,6 +1015,7 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
             var source = BindingSource.None;
             TypedConstant? typedKey = null;
             string? bindingName = null;
+            var parameterLocation = parameter.Locations.Length > 0 ? parameter.Locations[0] : null;
 
             foreach (var attribute in parameter.GetAttributes())
             {
@@ -983,7 +1034,15 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
                     case BindingSource.FromQuery:
                     case BindingSource.FromHeader:
                     case BindingSource.FromForm:
-                        bindingName = GetBindingAttributeName(attribute) ?? bindingName;
+                        var bindingResult = GetBindingAttributeName(attribute, cancellationToken);
+                        if (bindingResult.IsInvalid)
+                        {
+                            ReportDiagnostic(reportDiagnostic, InvalidBindingAnnotationDiagnostic,
+                                bindingResult.Location ?? parameterLocation, parameter.Name);
+                            continue;
+                        }
+
+                        bindingName = bindingResult.Name ?? bindingName;
                         break;
                     case BindingSource.FromKeyedServices:
                         typedKey = attribute.ConstructorArguments.Length > 0 ? attribute.ConstructorArguments[0] : null;
@@ -1001,22 +1060,31 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
         return methodParameters.ToEquatableImmutable();
     }
 
-    private static string? GetBindingAttributeName(AttributeData attribute)
+    private static BindingNameResult GetBindingAttributeName(AttributeData attribute, CancellationToken cancellationToken)
     {
         foreach (var namedArg in attribute.NamedArguments)
         {
-            if (string.Equals(namedArg.Key, NameAttributeNamedParameter, StringComparison.Ordinal) && namedArg.Value.Value is string namedValue)
+            if (!string.Equals(namedArg.Key, NameAttributeNamedParameter, StringComparison.Ordinal))
+                continue;
+
+            if (namedArg.Value.Value is string namedValue)
             {
                 var normalized = NormalizeBindingName(namedValue);
-                if (normalized is not null)
-                    return normalized;
+                var invalid = normalized is null && !string.IsNullOrEmpty(namedValue);
+                var location = invalid ? GetAttributeLocation(attribute, cancellationToken) : null;
+                return new BindingNameResult(normalized, true, invalid, location);
             }
         }
 
         if (attribute.ConstructorArguments.Length > 0 && attribute.ConstructorArguments[0].Value is string constructorName)
-            return NormalizeBindingName(constructorName);
+        {
+            var normalized = NormalizeBindingName(constructorName);
+            var invalid = normalized is null && !string.IsNullOrEmpty(constructorName);
+            var location = invalid ? GetAttributeLocation(attribute, cancellationToken) : null;
+            return new BindingNameResult(normalized, true, invalid, location);
+        }
 
-        return null;
+        return new BindingNameResult(null, false, false, null);
     }
 
     private static string? NormalizeBindingName(string? value)
@@ -1028,12 +1096,36 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
         return trimmed.Length > 0 ? trimmed : null;
     }
 
+    private static Location? GetAttributeLocation(AttributeData attribute, CancellationToken cancellationToken)
+    {
+        var syntaxReference = attribute.ApplicationSyntaxReference;
+        if (syntaxReference is null)
+            return null;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var syntax = syntaxReference.GetSyntax(cancellationToken);
+        return syntax?.GetLocation();
+    }
+
+    private static void ReportDiagnostic(
+        Action<Diagnostic>? reportDiagnostic,
+        DiagnosticDescriptor descriptor,
+        Location? location,
+        params object[] messageArgs)
+    {
+        if (reportDiagnostic is null)
+            return;
+
+        var diagnostic = Diagnostic.Create(descriptor, location ?? Location.None, messageArgs);
+        reportDiagnostic(diagnostic);
+    }
+
     private static void GenerateSource(SourceProductionContext context, ImmutableArray<RequestHandler> requestHandlers)
     {
         context.CancellationToken.ThrowIfCancellationRequested();
 
         var sorted = SortRequestHandlers(requestHandlers);
-        sorted = EnsureUniqueEndpointNames(sorted);
+        sorted = EnsureUniqueEndpointNames(context, sorted);
 
         GenerateAddEndpointHandlersClass(context, sorted);
         GenerateUseEndpointHandlersClass(context, sorted);
@@ -1049,7 +1141,7 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
         return [..array];
     }
 
-    private static ImmutableArray<RequestHandler> EnsureUniqueEndpointNames(ImmutableArray<RequestHandler> requestHandlers)
+    private static ImmutableArray<RequestHandler> EnsureUniqueEndpointNames(SourceProductionContext context, ImmutableArray<RequestHandler> requestHandlers)
     {
         var collidingHandlers = GetRequestHandlersWithNameCollisions(requestHandlers);
         if (collidingHandlers.IsEmpty)
@@ -1059,6 +1151,13 @@ public sealed partial class MinimalApiGenerator : IIncrementalGenerator
         foreach (var index in collidingHandlers)
         {
             var handler = builder[index];
+            var metadataName = handler.Configuration.Metadata.Name;
+            if (!string.IsNullOrEmpty(metadataName))
+            {
+                var diagnosticLocation = handler.Location ?? Location.None;
+                context.ReportDiagnostic(Diagnostic.Create(DuplicateEndpointNameDiagnostic, diagnosticLocation, metadataName!, handler.Method.Name));
+            }
+
             var configuration = handler.Configuration;
             var metadata = configuration.Metadata with
             {

--- a/tests/GeneratedEndpoints.Tests/DiagnosticTests.cs
+++ b/tests/GeneratedEndpoints.Tests/DiagnosticTests.cs
@@ -1,0 +1,89 @@
+using System.Linq;
+using GeneratedEndpoints.Tests.Common;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace GeneratedEndpoints.Tests;
+
+public class DiagnosticTests
+{
+    [Fact]
+    public void Reports_InvalidEndpointContainer()
+    {
+        var source = """
+            internal struct InvalidEndpoints
+            {
+                [MapGet("/invalid")]
+                public void Handle()
+                {
+                }
+            }
+            """;
+
+        var result = TestHelpers.RunGenerator(TestHelpers.GetSources(source, withNamespace: false));
+        var diagnostic = Assert.Single(result.Diagnostics, d => d.Id == "GE0002");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void Reports_ConflictingAuthorizationAttributes()
+    {
+        var source = """
+            internal sealed class AuthorizationEndpoints
+            {
+                [AllowAnonymous]
+                [RequireAuthorization]
+                [MapGet("/conflict")]
+                public void Handle()
+                {
+                }
+            }
+            """;
+
+        var result = TestHelpers.RunGenerator(TestHelpers.GetSources(source, withNamespace: false));
+        var diagnostic = Assert.Single(result.Diagnostics, d => d.Id == "GE0003");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void Reports_InvalidBindingAnnotation()
+    {
+        var source = """
+            internal sealed class BindingEndpoints
+            {
+                [MapGet("/items/{id}")]
+                public void Get([FromRoute(Name = " ")] int id)
+                {
+                }
+            }
+            """;
+
+        var result = TestHelpers.RunGenerator(TestHelpers.GetSources(source, withNamespace: false));
+        var diagnostic = Assert.Single(result.Diagnostics, d => d.Id == "GE0005");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void Reports_DuplicateEndpointNames()
+    {
+        var source = """
+            internal sealed class DuplicateEndpoints
+            {
+                [MapGet("/one", Name = "SharedName")]
+                public void One()
+                {
+                }
+
+                [MapPost("/two", Name = "SharedName")]
+                public void Two()
+                {
+                }
+            }
+            """;
+
+        var result = TestHelpers.RunGenerator(TestHelpers.GetSources(source, withNamespace: false));
+        var duplicateDiagnostics = result.Diagnostics.Where(d => d.Id == "GE0004").ToList();
+        Assert.Equal(2, duplicateDiagnostics.Count);
+        Assert.All(duplicateDiagnostics, d => Assert.Equal(DiagnosticSeverity.Warning, d.Severity));
+    }
+}


### PR DESCRIPTION
## Summary
- add diagnostic descriptors for common misconfigurations and report them while transforming request handlers
- record attribute locations on handlers so duplicate endpoint names can be reported instead of silently renaming
- add regression tests that exercise the new diagnostics for authorization conflicts, invalid containers, binding names, and duplicate names

## Testing
- not run (dotnet CLI is unavailable in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a22a124948328926bc0aac6f38554)