### PR TITLE
Add MapGroup individual test

### DIFF
--- a/tests/GeneratedEndpoints.Tests/IndividualTests.cs
+++ b/tests/GeneratedEndpoints.Tests/IndividualTests.cs
@@ -195,6 +195,13 @@ public class IndividualTests
     }
 
     [Fact]
+    public async Task GroupName()
+    {
+        var source = AuthorizationScenario(groupName: "IndividualGroup");
+        await VerifyIndividualAsync(source, nameof(GroupName));
+    }
+
+    [Fact]
     public async Task ExcludeFromDescription()
     {
         var source = AuthorizationScenario(excludeFromDescription: true);


### PR DESCRIPTION
## Summary
- add a GroupName scenario to the individual tests to cover MapGroup generation

## Testing
- `dotnet test tests/GeneratedEndpoints.Tests/GeneratedEndpoints.Tests.csproj -c Release --filter "FullyQualifiedName~GroupName"`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a91d1ebd48328a76e4d362c457829)