### PR TITLE
Use EquatableImmutableArray for request handlers

### DIFF
--- a/src/GeneratedEndpoints/AddEndpointHandlersGenerator.cs
+++ b/src/GeneratedEndpoints/AddEndpointHandlersGenerator.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Text;
+﻿using System.Text;
 using GeneratedEndpoints.Common;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
@@ -13,7 +12,7 @@ namespace GeneratedEndpoints;
 
 internal static class AddEndpointHandlersGenerator
 {
-    public static void GenerateSource(SourceProductionContext context, ImmutableArray<RequestHandler> requestHandlers)
+    public static void GenerateSource(SourceProductionContext context, EquatableImmutableArray<RequestHandler> requestHandlers)
     {
         context.CancellationToken.ThrowIfCancellationRequested();
 
@@ -63,14 +62,14 @@ internal static class AddEndpointHandlersGenerator
         context.AddSource(AddEndpointHandlersMethodHint, SourceText.From(sourceText, Encoding.UTF8));
     }
 
-    private static List<string> GetDistinctNonStaticClassNames(ImmutableArray<RequestHandler> requestHandlers)
+    private static List<string> GetDistinctNonStaticClassNames(EquatableImmutableArray<RequestHandler> requestHandlers)
     {
         var classNames = new List<string>();
-        if (requestHandlers.IsDefaultOrEmpty)
+        if (requestHandlers.Count == 0)
             return classNames;
 
         var seen = new HashSet<string>(StringComparer.Ordinal);
-        for (var index = 0; index < requestHandlers.Length; index++)
+        for (var index = 0; index < requestHandlers.Count; index++)
         {
             var requestHandler = requestHandlers[index];
             if (requestHandler.Class.IsStatic)

--- a/src/GeneratedEndpoints/Common/EquatableImmutableArray`1.cs
+++ b/src/GeneratedEndpoints/Common/EquatableImmutableArray`1.cs
@@ -21,6 +21,11 @@ public readonly struct EquatableImmutableArray<T> : IEquatable<EquatableImmutabl
     private ImmutableArray<T> Array => _array ?? ImmutableArray<T>.Empty;
     private readonly ImmutableArray<T>? _array;
 
+    internal ImmutableArray<T> AsImmutableArray()
+    {
+        return Array;
+    }
+
     internal EquatableImmutableArray(ImmutableArray<T>? array)
     {
         _array = array;

--- a/src/GeneratedEndpoints/MinimalApiGenerator.cs
+++ b/src/GeneratedEndpoints/MinimalApiGenerator.cs
@@ -171,19 +171,16 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         UseEndpointHandlersGenerator.GenerateSource(context, normalized);
     }
 
-    private static ImmutableArray<RequestHandler> NormalizeRequestHandlers(EquatableImmutableArray<RequestHandler> requestHandlers)
+    private static EquatableImmutableArray<RequestHandler> NormalizeRequestHandlers(EquatableImmutableArray<RequestHandler> requestHandlers)
     {
-        if (requestHandlers.Count == 0)
-            return ImmutableArray<RequestHandler>.Empty;
-
-        if (requestHandlers.Count == 1)
-            return [requestHandlers[0]];
+        if (requestHandlers.Count <= 1)
+            return requestHandlers;
 
         var sorted = SortRequestHandlers(requestHandlers);
         return EnsureUniqueEndpointNames(sorted);
     }
 
-    private static ImmutableArray<RequestHandler> SortRequestHandlers(EquatableImmutableArray<RequestHandler> requestHandlers)
+    private static EquatableImmutableArray<RequestHandler> SortRequestHandlers(EquatableImmutableArray<RequestHandler> requestHandlers)
     {
         var count = requestHandlers.Count;
 
@@ -194,15 +191,15 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
         }
 
         builder.Sort(RequestHandlerComparer.Instance);
-        return builder.MoveToImmutable();
+        return builder.ToEquatableImmutable();
     }
 
-    private static ImmutableArray<RequestHandler> EnsureUniqueEndpointNames(ImmutableArray<RequestHandler> requestHandlers)
+    private static EquatableImmutableArray<RequestHandler> EnsureUniqueEndpointNames(EquatableImmutableArray<RequestHandler> requestHandlers)
     {
-        if (requestHandlers.IsDefaultOrEmpty)
+        if (requestHandlers.Count == 0)
             return requestHandlers;
 
-        var handlerCount = requestHandlers.Length;
+        var handlerCount = requestHandlers.Count;
         Dictionary<HandlerNameKey, CollisionInfo>? nameToCollision = null;
         ImmutableArray<RequestHandler>.Builder? builder = null;
 
@@ -221,7 +218,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
                 continue;
             }
 
-            builder ??= requestHandlers.ToBuilder();
+            builder ??= requestHandlers.AsImmutableArray().ToBuilder();
             handler = builder[index];
             if (!collision.FirstHandlerRenamed)
             {
@@ -240,7 +237,7 @@ public sealed class MinimalApiGenerator : IIncrementalGenerator
             nameToCollision[key] = collision;
         }
 
-        return builder?.MoveToImmutable() ?? requestHandlers;
+        return builder is null ? requestHandlers : builder.ToEquatableImmutable();
     }
 
     private static string GetFullyQualifiedMethodDisplayName(RequestHandler requestHandler)

--- a/src/GeneratedEndpoints/UseEndpointHandlersGenerator.cs
+++ b/src/GeneratedEndpoints/UseEndpointHandlersGenerator.cs
@@ -13,7 +13,7 @@ namespace GeneratedEndpoints;
 
 internal static class UseEndpointHandlersGenerator
 {
-    public static void GenerateSource(SourceProductionContext context, ImmutableArray<RequestHandler> requestHandlers)
+    public static void GenerateSource(SourceProductionContext context, EquatableImmutableArray<RequestHandler> requestHandlers)
     {
         context.CancellationToken.ThrowIfCancellationRequested();
 
@@ -66,7 +66,7 @@ internal static class UseEndpointHandlersGenerator
         if (groupedClasses.Count > 0)
             source.AppendLine();
 
-        for (var index = 0; index < requestHandlers.Length; index++)
+        for (var index = 0; index < requestHandlers.Count; index++)
         {
             if (index > 0)
                 source.AppendLine();
@@ -87,9 +87,9 @@ internal static class UseEndpointHandlersGenerator
         context.AddSource(UseEndpointHandlersMethodHint, SourceText.From(sourceText, Encoding.UTF8));
     }
 
-        private static bool HasRateLimitedHandlers(ImmutableArray<RequestHandler> requestHandlers)
+    private static bool HasRateLimitedHandlers(EquatableImmutableArray<RequestHandler> requestHandlers)
     {
-        for (var index = 0; index < requestHandlers.Length; index++)
+        for (var index = 0; index < requestHandlers.Count; index++)
         {
             var handler = requestHandlers[index];
             if (handler.Method.Configuration.RequireRateLimiting)
@@ -99,14 +99,14 @@ internal static class UseEndpointHandlersGenerator
         return false;
     }
 
-    private static List<RequestHandlerClass> GetClassesWithMapGroups(ImmutableArray<RequestHandler> requestHandlers)
+    private static List<RequestHandlerClass> GetClassesWithMapGroups(EquatableImmutableArray<RequestHandler> requestHandlers)
     {
         var groupedClasses = new List<RequestHandlerClass>();
-        if (requestHandlers.IsDefaultOrEmpty)
+        if (requestHandlers.Count == 0)
             return groupedClasses;
 
         var seen = new HashSet<string>(StringComparer.Ordinal);
-        for (var index = 0; index < requestHandlers.Length; index++)
+        for (var index = 0; index < requestHandlers.Count; index++)
         {
             var handler = requestHandlers[index];
             var handlerClass = handler.Class;
@@ -603,12 +603,12 @@ internal static class UseEndpointHandlersGenerator
         };
     }
 
-    private static StringBuilder GetUseEndpointHandlersStringBuilder(ImmutableArray<RequestHandler> requestHandlers)
+    private static StringBuilder GetUseEndpointHandlersStringBuilder(EquatableImmutableArray<RequestHandler> requestHandlers)
     {
         const int baseSize = 4096;
         const int perHandler = 512;
 
-        var handlerCount = Math.Max(requestHandlers.Length, 0);
+        var handlerCount = Math.Max(requestHandlers.Count, 0);
         var estimate = baseSize + (long)perHandler * handlerCount;
         estimate = (long)(estimate * 1.10);
 


### PR DESCRIPTION
## Summary
- keep request-handler pipelines in the generator on EquatableImmutableArray to avoid repeated conversions
- expose the underlying ImmutableArray from EquatableImmutableArray so callers can clone only when necessary
- update both code-generation passes to operate on EquatableImmutableArray inputs

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab680d908832891404612094c16f2)